### PR TITLE
driver: cache stats values

### DIFF
--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -63,7 +63,7 @@ type ExecTwo interface {
 	// Stats returns current resource utilization.
 	//
 	// Must only be called after Start.
-	Stats() resources.Utilization
+	Stats() *resources.Utilization
 
 	// Signal [kill()] the process.
 	//
@@ -167,7 +167,7 @@ func (e *exe) Stop(signal string, timeout time.Duration) error {
 	return err
 }
 
-func (e *exe) Stats() resources.Utilization {
+func (e *exe) Stats() *resources.Utilization {
 	memCurrentS, _ := e.readCG("memory.current")
 	memCurrent, _ := strconv.Atoi(memCurrentS)
 
@@ -184,7 +184,7 @@ func (e *exe) Stats() resources.Utilization {
 	specs := resources.GetSpecs()
 	ticks := (.01 * totalPct) * resources.Percent(specs.Ticks()/specs.Cores)
 
-	return resources.Utilization{
+	return &resources.Utilization{
 		// memory stats
 		Memory: uint64(memCurrent),
 		Swap:   uint64(swapCurrent),

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -458,8 +458,9 @@ func netns(c *drivers.TaskConfig) string {
 func (p *Plugin) stats(ctx context.Context, ch chan<- *drivers.TaskResourceUsage, interval time.Duration, h *task.Handle) {
 	defer close(ch)
 
-	// Nomad client asks for 1 second intervals, but other drivers run a
-	// stats collector in the background on a much slower period.
+	// Nomad client asks for 1 second intervals. Our handle will cache results
+	// so as to not crush the kernel with scanning of cgroups, on a 10 second
+	// TTL for recorded values.
 
 	ticks, stop := libtime.SafeTimer(interval)
 	defer stop()


### PR DESCRIPTION
This PR ensures a task's cgroup will only be scanned once
every 10 seconds, instead of being driven to scan once per
second by requests from Nomad.

A similar caching strategy(1) was also part of Nomad <= 1.6 but accidentally
got removed in 1.7; we need to add it back for the builtin drivers
as well. (explains https://github.com/hashicorp/nomad/issues/20042)

(1) the builtin drivers ran a background goroutine collecting
stats periodically rather than being request driven, but it's just two
ways of placing a frequency limit on actually collecting stats
