### PR TITLE
driver: keep shim alive to report exit code

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -194,7 +194,7 @@ func TestBasic_Passwd(t *testing.T) {
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/passwd.hcl")
 
 	// make sure job is failing (cannot read /etc/passwd)
-	time.Sleep(5 * time.Second)
+	time.Sleep(20 * time.Second)
 	jobStatus := run(t, ctx, "nomad", "job", "status", "passwd")
 	must.RegexMatch(t, deadRe, jobStatus)
 
@@ -243,8 +243,8 @@ func TestBasic_ProcessNamespace(t *testing.T) {
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/ps.hcl")
 
 	logs := logs2(t, ctx, "ps", "ps")
-	lines := strings.Split(logs, "\n") // header and ps
-	must.SliceLen(t, 2, lines, must.Sprintf("expected 2 lines, got %q", logs))
+	lines := strings.Split(logs, "\n") // header + shim + ps
+	must.SliceLen(t, 3, lines, must.Sprintf("expected 3 lines, got %q", logs))
 }
 
 func TestBasic_Exit7(t *testing.T) {
@@ -254,7 +254,7 @@ func TestBasic_Exit7(t *testing.T) {
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/exit7.hcl")
 
 	// make sure job is failing (script returns exit code 7)
-	time.Sleep(5 * time.Second)
+	time.Sleep(15 * time.Second)
 	jobStatus := run(t, ctx, "nomad", "job", "status", "exit7")
 	must.RegexMatch(t, deadRe, jobStatus)
 

--- a/e2e/jobs/cgroup.hcl
+++ b/e2e/jobs/cgroup.hcl
@@ -26,7 +26,7 @@ job "cgroup" {
       config {
         command = "/usr/bin/cat"
         args    = ["/proc/self/cgroup"]
-        unveil  = ["r:/proc/self/cgroup"]
+        unveil  = ["r:/proc"]
       }
 
       resources {

--- a/pkg/resources/process/wait_test.go
+++ b/pkg/resources/process/wait_test.go
@@ -5,25 +5,42 @@ package process
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/shoenig/test/must"
 )
 
+func writeStatus(t *testing.T, code int) string {
+	taskDir := t.TempDir()
+	path := filepath.Join(taskDir, "local", ".exit_status.txt")
+	must.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	must.NoError(t, os.WriteFile(path, []byte(strconv.FormatInt(int64(code), 10)), 0o644))
+	return taskDir
+}
+
 func TestPID_Wait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// when waiting via PID (the orphan case) we get the exit code from
+	// the .exit_status.txt file written by the shim upon task process exit
+	taskDir := writeStatus(t, 0)
 
 	start := time.Now()
 
 	cmd := exec.CommandContext(ctx, "sleep", ".1s")
 	must.NoError(t, cmd.Start())
 
-	waitCh := WaitPID(cmd.Process.Pid).Wait()
+	waitCh := WaitPID(cmd.Process.Pid, taskDir).Wait()
 	result := <-waitCh
 
+	// ensure the pidfd_open + poll magic works; we actually wait for the
+	// process to die before the plugin asks about its exit status
 	must.Greater(t, 100*time.Millisecond, time.Since(start))
 	must.NoError(t, result.Err)
 	must.Zero(t, result.ExitCode)
@@ -33,10 +50,14 @@ func TestPID_WaitFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sleep", "abc") // exit 1
+	// when waiting via PID (the orphan case) we get the exit code from
+	// the .exit_status.txt file written by the shim upon task process exit
+	taskDir := writeStatus(t, 1)
+
+	cmd := exec.CommandContext(ctx, "sleep", "abc")
 	must.NoError(t, cmd.Start())
 
-	waitCh := WaitPID(cmd.Process.Pid).Wait()
+	waitCh := WaitPID(cmd.Process.Pid, taskDir).Wait()
 	result := <-waitCh
 
 	must.NoError(t, result.Err)

--- a/pkg/resources/process/wait_test.go
+++ b/pkg/resources/process/wait_test.go
@@ -15,51 +15,69 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-func writeStatus(t *testing.T, code int) string {
+// writeStatus will write the given status code to a .exit_status.txt file
+// and return the filepath to that file.
+//
+// if delay is 0, this function blocks until the file exists
+//
+// otherwise, this function is non-blocking and creates the file in a goroutine
+// after the delay has elapsed
+func writeStatus(t *testing.T, code int, delay time.Duration) string {
 	taskDir := t.TempDir()
 	path := filepath.Join(taskDir, "local", ".exit_status.txt")
 	must.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	must.NoError(t, os.WriteFile(path, []byte(strconv.FormatInt(int64(code), 10)), 0o644))
+	switch delay {
+	case 0:
+		time.Sleep(delay)
+		must.NoError(t, os.WriteFile(path, []byte(strconv.FormatInt(int64(code), 10)), 0o644))
+	default:
+		go func() {
+			time.Sleep(delay)
+			must.NoError(t, os.WriteFile(path, []byte(strconv.FormatInt(int64(code), 10)), 0o644))
+		}()
+	}
 	return taskDir
 }
 
-func TestPID_Wait(t *testing.T) {
+func TestPID_Wait_already_exited(t *testing.T) {
+	// in this case the child (shim) already exited and set a status code
+	// file for us to read back
+	taskDir := writeStatus(t, 7, 0)
+
+	pid := 1 // does not matter
+	waitCh := WaitPID(pid, taskDir).Wait()
+	result := <-waitCh
+
+	must.NoError(t, result.Err)
+	must.Eq(t, 7, result.ExitCode)
+}
+
+func TestPID_Wait_poll(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	// when waiting via PID (the orphan case) we get the exit code from
-	// the .exit_status.txt file written by the shim upon task process exit
-	taskDir := writeStatus(t, 0)
 
 	start := time.Now()
 
 	cmd := exec.CommandContext(ctx, "sleep", ".1s")
 	must.NoError(t, cmd.Start())
 
+	// when waiting via PID (the orphan case) we get the exit code from
+	// the .exit_status.txt file written by the shim upon task process exit
+	//
+	// since we aren't running in the context of the real shim here, just
+	// fudge an exit code status file ... but wait long enough for the Wait()
+	// below to actually start polling the process we started above
+	//
+	// please never use this test case as inspiration
+	taskDir := writeStatus(t, 7, 90*time.Millisecond)
+
 	waitCh := WaitPID(cmd.Process.Pid, taskDir).Wait()
 	result := <-waitCh
 
 	// ensure the pidfd_open + poll magic works; we actually wait for the
-	// process to die before the plugin asks about its exit status
+	// process to die before the plugin asks about its exit status which
+	// we retrive from the .exit_status.txt file
 	must.Greater(t, 100*time.Millisecond, time.Since(start))
 	must.NoError(t, result.Err)
-	must.Zero(t, result.ExitCode)
-}
-
-func TestPID_WaitFailure(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// when waiting via PID (the orphan case) we get the exit code from
-	// the .exit_status.txt file written by the shim upon task process exit
-	taskDir := writeStatus(t, 1)
-
-	cmd := exec.CommandContext(ctx, "sleep", "abc")
-	must.NoError(t, cmd.Start())
-
-	waitCh := WaitPID(cmd.Process.Pid, taskDir).Wait()
-	result := <-waitCh
-
-	must.NoError(t, result.Err)
-	must.One(t, result.ExitCode)
+	must.Eq(t, 7, result.ExitCode)
 }

--- a/pkg/task/handle.go
+++ b/pkg/task/handle.go
@@ -54,13 +54,12 @@ func NewHandle(runner shim.ExecTwo, config *drivers.TaskConfig) (*Handle, time.T
 }
 
 func RecreateHandle(runner shim.ExecTwo, config *drivers.TaskConfig, started time.Time) *Handle {
-	clock := libtime.SystemClock()
 	return &Handle{
 		pid:     runner.PID(),
 		runner:  runner,
 		config:  config,
 		state:   drivers.TaskStateUnknown,
-		clock:   clock,
+		clock:   libtime.SystemClock(),
 		started: started,
 		result:  nil,
 	}

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -5,6 +5,9 @@ package util
 
 import (
 	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 // NullCloser returns an implementation of io.WriteCloser that will always
@@ -19,4 +22,19 @@ type writeCloser struct {
 
 func (*writeCloser) Close() error {
 	return nil
+}
+
+// OpenPipes opens the given paths for standard IO as named pipes.
+//
+// The returned values must be closed by the caller.
+func OpenPipes(stdout, stderr string) (io.WriteCloser, io.WriteCloser, error) {
+	a, err := os.OpenFile(stdout, unix.O_WRONLY, os.ModeNamedPipe)
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := os.OpenFile(stderr, unix.O_WRONLY, os.ModeNamedPipe)
+	if err != nil {
+		return nil, nil, err
+	}
+	return a, b, nil
 }

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -304,24 +304,21 @@ func TestFunctional_cases(t *testing.T) {
 			user:           "nomad-80000",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 1},
-			stderrRe:       regexp.MustCompile(`failed to exec command "/usr/bin/env": permission denied`),
+			exp:            &drivers.ExitResult{ExitCode: 2},
 		},
 		{
 			name:           "run 'env' as nobody without default paths",
 			user:           "nobody",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 1},
-			stderrRe:       regexp.MustCompile(`failed to exec command "/usr/bin/env": permission denied`),
+			exp:            &drivers.ExitResult{ExitCode: 2},
 		},
 		{
 			name:           "run 'env' as root without default paths",
 			user:           "root",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 1},
-			stderrRe:       regexp.MustCompile(`failed to exec command "/usr/bin/env": permission denied`),
+			exp:            &drivers.ExitResult{ExitCode: 2},
 		},
 		// write to task directory
 		{


### PR DESCRIPTION
This PR fixes a design flaw where the exit code of a task process would
not be retrievable after a Nomad client restart. This is critical for
batch jobs, the success or failure of which are determined by their exit
code.

The fix is basically to have the exec2-shim process remain alive as a
parent of the task process and record the exit code to a known file
inside the task directory. That file is then read back by the plugin
after the task process exits. This path is only necessary in the reattach
case; wait.go now splits logic between waiting on a child and waiting
on an orphan. The orphan case makes use of the recent pidfd_open syscall
to acquire an FD on which we call poll, which returns when the process
exits. Unfortunately Linux does not yet provide a way to retrieve the
exit status information via the pidfd_* set of syscalls, and so we fallback
to the shim + file hack.

While fixing this I also realized the FIFO filepaths for logging were
incorrect - we were using the host-perspective paths instead of the
task mounts directory perspective. This is a requirement for working in
a production - hardened environment, and the bug became apparent because
the tests would no longer pass without the fix. The reason is because
before, the FIFOs were opened by the plugin (running as root) and the FD's
simply passed through unshare upon launch. Now, the shim opens the FIFOs
itself and would fail to do so with the incorrect host-perspective paths
due to them being owned by root.

Closes #9 