### PR TITLE
e2e: add a test demonstrating secrets/identity work

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -367,3 +367,17 @@ func TestBasic_Envoy(t *testing.T) {
 	envoyService := run(t, ctx, "nomad", "service", "info", "envoy")
 	must.StrContains(t, envoyService, "envoy-test")
 }
+
+func TestBasic_Secret(t *testing.T) {
+	ctx := setup(t)
+	defer purge(t, ctx, "secret")()
+
+	_ = run(t, ctx, "nomad", "job", "run", "./jobs/secret.hcl")
+
+	statusOutput := run(t, ctx, "nomad", "job", "status", "secret")
+	alloc := allocFromJobStatus(t, statusOutput)
+
+	output := logs(t, ctx, alloc)
+	tokenRe := regexp.MustCompile(`[\w-]+`)
+	must.RegexMatch(t, tokenRe, output)
+}

--- a/e2e/jobs/secret.hcl
+++ b/e2e/jobs/secret.hcl
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "secret" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "cat" {
+      driver = "exec2"
+
+      config {
+        command = "cat"
+        args    = ["${NOMAD_SECRETS_DIR}/nomad_token"]
+      }
+
+      identity {
+        env  = false
+        file = true
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/nomad-driver-exec2/issues/15 

(which was fixed in https://github.com/hashicorp/nomad/pull/20589)