### PR TITLE
build: create linux package during CRT build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,3 +79,33 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/actions-packaging-linux@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "nomad-driver-exec2 is a HashiCorp Nomad task driver for Linux."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.set-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/nomad-driver-exec2"
+          license: "MPL-2.0"
+          binary: "dist/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
+          postinstall: ".release/linux/postinst"
+          postremove: ".release/linux/postrm"
+
+      - name: Set Package Names
+        if: ${{ matrix.goos == 'linux' }}
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}

--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p /opt/nomad/plugins
+ln -s /usr/bin/nomad-driver-exec2 /opt/nomad/plugins/nomad-driver-exec2

--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm /opt/nomad/plugins/nomad-driver-exec2


### PR DESCRIPTION
This PR creates .deb and .rpm Linux packages of the nomad-driver-exec2
task driver. Given limitations of our packaging system the driver gets
installed in /usr/bin/ but then gets linked to /opt/nomad/plugins/ during
the install steps (and likewise removed during uninstall). This way the
plugin Just Works with the default configuration of Nomad.

Closes https://github.com/hashicorp/nomad-driver-exec2/issues/4