### PR TITLE
config: do not require unveil_paths being set

### DIFF
--- a/plugin/about.go
+++ b/plugin/about.go
@@ -51,7 +51,7 @@ var driverConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		hclspec.NewAttr("unveil_by_task", "bool", false),
 		hclspec.NewLiteral("false"),
 	),
-	"unveil_paths": hclspec.NewAttr("unveil_paths", "list(string)", true),
+	"unveil_paths": hclspec.NewAttr("unveil_paths", "list(string)", false),
 })
 
 // taskConfigSpec is the HCL configuration set for the task on the jobspec


### PR DESCRIPTION
This PR makes it so that the plugin is usable by
default with no config file. In this case the default
set of unveil_paths is applied, which is good enough
for running things out of /bin, /usr/bin, etc.
