### PR TITLE
Release/0.1.0 alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0-alpha.2 (May 24, 2024)
+
+Second alpha release of initial v0.1.0 version.

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta.1", "rc1.1", etc.
-	VersionPrerelease = "alpha.2"
+	VersionPrerelease = "dev"
 
 	// VersionMetadata is metadata further describing the build type.
 	VersionMetadata = ""

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta.1", "rc1.1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "alpha.2"
 
 	// VersionMetadata is metadata further describing the build type.
 	VersionMetadata = ""


### PR DESCRIPTION
finishing nomad-driver-exec2 `v0.1.0-alpha.2` release 