### PR TITLE
build: fix typo in package build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
           name: ${{ github.event.repository.name }}
           description: "nomad-driver-exec2 is a HashiCorp Nomad task driver for Linux."
           arch: ${{ matrix.goarch }}
-          version: ${{ needs.set-product-version.outputs.product-version }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/nomad-driver-exec2"
           license: "MPL-2.0"


### PR DESCRIPTION
Otherwise deb/rpm packages aren't named correctly.