### PR TITLE
plugin: able to use task sandbox tmp directory

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -163,6 +163,20 @@ func TestBasic_Env(t *testing.T) {
 	must.RegexMatch(t, containsUserRe, output)
 }
 
+func TestBasic_Mktemp(t *testing.T) {
+	ctx := setup(t)
+	defer purge(t, ctx, "mktemp")()
+
+	_ = run(t, ctx, "nomad", "job", "run", "./jobs/mktemp.hcl")
+	statusOutput := run(t, ctx, "nomad", "job", "status", "mktemp")
+	alloc := allocFromJobStatus(t, statusOutput)
+
+	// contains reasonable mktemp output
+	resultRe := regexp.MustCompile(`\w+-mktemp/tmp/tmp\.\w+`)
+	output := logs(t, ctx, alloc)
+	must.RegexMatch(t, resultRe, output)
+}
+
 func TestBasic_Sleep(t *testing.T) {
 	ctx := setup(t)
 	defer purge(t, ctx, "sleep")()

--- a/e2e/jobs/mktemp.hcl
+++ b/e2e/jobs/mktemp.hcl
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "mktemp" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "mktemp" {
+      driver = "exec2"
+
+      config {
+        command = "mktemp"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
+      }
+    }
+  }
+}

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -515,6 +515,8 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_TASK_DIR"])
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_ALLOC_DIR"])
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_SECRETS_DIR"])
+		parent := filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"])
+		unveil = append(unveil, "rwxc:"+filepath.Join(parent, "tmp"))
 	}
 
 	if len(taskConfig.Unveil) > 0 {

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -411,6 +411,15 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`root\s+1.+ps aux`), // out ps is pid 1
 		},
+		// able to use TMPDIR
+		{
+			name:           "use TMPDIR",
+			user:           "nomad-82000",
+			command:        "mktemp",
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`\w+/tmp/tmp\.\w+`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This PR fixes a bug where the tmp directory created on behalf of a task
in its sandbox directory was not accessible to tasks. Adds some tests
to make sure this keeps working.

Fixes #37
