### PR TITLE
packaging: fix plugins directory filepath

### DIFF
--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-mkdir -p /opt/nomad/plugins
-ln -s /usr/bin/nomad-driver-exec2 /opt/nomad/plugins/nomad-driver-exec2
+# Ensure <data_dir>/plugins exists.
+mkdir -p /opt/nomad/data/plugins
+
+# Symlink driver in the plugins directory.
+ln -s /usr/bin/nomad-driver-exec2 /opt/nomad/data/plugins/nomad-driver-exec2

--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-rm /opt/nomad/plugins/nomad-driver-exec2
+# Remove symlink from plugins directory.
+rm /opt/nomad/data/plugins/nomad-driver-exec2


### PR DESCRIPTION
When installing Nomad via Linux packaging the data directory is placed
at `/opt/nomad/data`, and the default plugins directory is a child of
that, i.e. `/opt/nomad/data/plugins`.

This PR fixes the linux package for exec2 to symlink the driver into the
correct path (it left off the `/data/` part) such that the driver works
out of the box when doing:

```
apt/yum install nomad nomad-driver-exec2
```

I believe we'll need to fix podman as well which copied exec2
https://github.com/hashicorp/nomad-driver-podman/blob/main/.release/linux/postinst#L3