### PR TITLE
exec2: oom_score_adj support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ config {
   access to the task (requires `unveil_by_task` in plugin config).
 
   - `oom_score_adj` - (optional) - The likelihood of the task being OOM killed,
-  must be a positive integer.
+  must be a positive integer. Defaults to `0`.
 
 ##### cpu
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,10 @@ plugin configuration.
 
 ```hcl
 config {
-  command = "/usr/bin/cat"
-  args    = ["/etc/os-release"]
-  unveil  = ["r:/etc/os-release"]
+  command       = "/usr/bin/cat"
+  args          = ["/etc/os-release"]
+  unveil        = ["r:/etc/os-release"]
+  oom_score_adj = 500
 }
 ```
 
@@ -203,6 +204,9 @@ config {
 
   - `unveil` - (optional) - A list of additional filesystem paths to provide
   access to the task (requires `unveil_by_task` in plugin config).
+
+  - `oom_score_adj` - (optional) - The likelihood of the task being OOM killed,
+  must be a positive integer.
 
 ##### cpu
 

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -395,3 +395,13 @@ func TestBasic_Secret(t *testing.T) {
 	tokenRe := regexp.MustCompile(`[\w-]+`)
 	must.RegexMatch(t, tokenRe, output)
 }
+
+func TestBasic_OomScoreAdj(t *testing.T) {
+	ctx := setup(t)
+	defer purge(t, ctx, "oom_score_adj")()
+
+	_ = run(t, ctx, "nomad", "job", "run", "./jobs/oom_score_adj.hcl")
+
+	statusOutput := run(t, ctx, "nomad", "job", "status", "oom_score_adj")
+	alloc := allocFromJobStatus(t, statusOutput)
+}

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -402,6 +402,10 @@ func TestBasic_OomScoreAdj(t *testing.T) {
 
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/oom_score_adj.hcl")
 
-	statusOutput := run(t, ctx, "nomad", "job", "status", "oom_score_adj")
-	alloc := allocFromJobStatus(t, statusOutput)
+	jobStatus := run(t, ctx, "nomad", "job", "status", "oom_score_adj")
+	must.RegexMatch(t, runningRe, jobStatus)
+
+	alloc := allocFromJobStatus(t, jobStatus)
+	output := logs(t, ctx, alloc)
+	must.StrContains(t, output, "oom")
 }

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -398,14 +398,10 @@ func TestBasic_Secret(t *testing.T) {
 
 func TestBasic_OomScoreAdj(t *testing.T) {
 	ctx := setup(t)
-	defer purge(t, ctx, "oom_score_adj")()
+	defer purge(t, ctx, "oom")()
 
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/oom_score_adj.hcl")
 
-	jobStatus := run(t, ctx, "nomad", "job", "status", "oom_score_adj")
+	jobStatus := run(t, ctx, "nomad", "job", "status", "oom")
 	must.RegexMatch(t, runningRe, jobStatus)
-
-	alloc := allocFromJobStatus(t, jobStatus)
-	output := logs(t, ctx, alloc)
-	must.StrContains(t, output, "oom")
 }

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -402,6 +402,16 @@ func TestBasic_OomScoreAdj(t *testing.T) {
 
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/oom_score_adj.hcl")
 
+	// run the job
 	jobStatus := run(t, ctx, "nomad", "job", "status", "oom")
 	must.RegexMatch(t, runningRe, jobStatus)
+
+	// stop the job
+	stopOutput := run(t, ctx, "nomad", "job", "stop", "oom")
+	must.StrContains(t, stopOutput, `finished with status "complete"`)
+
+	// check job is stopped
+	stopStatus := run(t, ctx, "nomad", "job", "status", "oom")
+	stoppedRe := regexp.MustCompile(`Status\s+=\s+dead\s+\(stopped\)`)
+	must.RegexMatch(t, stoppedRe, stopStatus)
 }

--- a/e2e/jobs/oom_score_adj.hcl
+++ b/e2e/jobs/oom_score_adj.hcl
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "oom_score_adj" {
+  type = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    task "oom_score_adj" {
+      driver = "exec2"
+
+      config {
+        command       = "sleep"
+        args          = ["infinity"]
+        oom_score_adj = 500
+      }
+    }
+  }
+}

--- a/e2e/jobs/oom_score_adj.hcl
+++ b/e2e/jobs/oom_score_adj.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-job "oom_score_adj" {
+job "oom" {
   type = "service"
 
   constraint {
@@ -20,13 +20,18 @@ job "oom_score_adj" {
       mode     = "fail"
     }
 
-    task "oom_score_adj" {
+    task "oom" {
       driver = "exec2"
 
       config {
         command       = "sleep"
         args          = ["infinity"]
         oom_score_adj = 500
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
       }
     }
   }

--- a/e2e/jobs/oom_score_adj.hcl
+++ b/e2e/jobs/oom_score_adj.hcl
@@ -10,6 +10,16 @@ job "oom_score_adj" {
   }
 
   group "group" {
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
     task "oom_score_adj" {
       driver = "exec2"
 

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -380,13 +380,6 @@ func (e *exe) constrain() error {
 }
 
 func (e *exe) setOomScoreAdj(pid int) error {
-	// make sure descendants of this process do not end up in the same oom group
-	// and thus inherit oom_score_adj settings
-	// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#memory-interface-files
-	if err := e.writeCG("memory.oom.group", "0"); err != nil {
-		return err
-	}
-
 	return os.WriteFile(
 		fmt.Sprintf("/proc/%d/oom_score_adj", pid),
 		[]byte(strconv.Itoa(int(e.env.OOMScoreAdj))),

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -30,6 +30,7 @@ type Options struct {
 	Arguments      []string
 	UnveilPaths    []string
 	UnveilDefaults bool
+	OOMScoreAdj    int
 }
 
 // Environment represents runtime configuration.
@@ -44,6 +45,7 @@ type Environment struct {
 	Memory       uint64            // memory in megabytes
 	MemoryMax    uint64            // memory_max in megabytes
 	CPUBandwidth uint64            // cpu / cores bandwidth
+	OOMScoreAdj  uint64            // oom_score_adj for the task
 }
 
 type ExecTwo interface {

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -131,6 +131,11 @@ func (e *exe) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to write cgroup constraints: %w", err)
 	}
 
+	// set oom_score_adj
+	if err = e.setOomScoreAdj(); err != nil {
+		return fmt.Errorf("failed to set oom score adj: %w", err)
+	}
+
 	// set permissions on fifos for logging output
 	if err = e.fixPipes(uid, gid); err != nil {
 		return fmt.Errorf("failed to set logging pipe ownership: %w", err)
@@ -370,6 +375,10 @@ func (e *exe) constrain() error {
 		}
 	}
 	return nil
+}
+
+func (e *exe) setOomScoreAdj() error {
+	return os.WriteFile("/proc/self/oom_score_adj", []byte(strconv.Itoa(int(e.env.OOMScoreAdj))), 0644)
 }
 
 var (

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -56,9 +56,10 @@ var driverConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 
 // taskConfigSpec is the HCL configuration set for the task on the jobspec
 var taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-	"command": hclspec.NewAttr("command", "string", true),
-	"args":    hclspec.NewAttr("args", "list(string)", false),
-	"unveil":  hclspec.NewAttr("unveil", "list(string)", false),
+	"command":       hclspec.NewAttr("command", "string", true),
+	"args":          hclspec.NewAttr("args", "list(string)", false),
+	"unveil":        hclspec.NewAttr("unveil", "list(string)", false),
+	"oom_score_adj": hclspec.NewAttr("oom_score_adj", "number", false),
 })
 
 var capabilities = &drivers.Capabilities{

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -87,7 +87,8 @@ type Config struct {
 // TaskConfig represents the exec2 driver task configuration that gets set in
 // a Nomad job file.
 type TaskConfig struct {
-	Command string   `codec:"command"`
-	Args    []string `codec:"args"`
-	Unveil  []string `codec:"unveil"`
+	Command     string   `codec:"command"`
+	Args        []string `codec:"args"`
+	Unveil      []string `codec:"unveil"`
+	OOMScoreAdj int      `codec:"oom_score_adj"`
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -533,5 +533,6 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		Arguments:      taskConfig.Args,
 		UnveilPaths:    unveil,
 		UnveilDefaults: p.config.UnveilDefaults,
+		OOMScoreAdj:    taskConfig.OOMScoreAdj,
 	}, nil
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -254,6 +254,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		"args", opts.Arguments,
 		"unveil_paths", opts.UnveilPaths,
 		"unveil_defaults", opts.UnveilDefaults,
+		"oom_score_adj", opts.OOMScoreAdj,
 	)
 
 	// create the runner and start it

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -225,6 +225,13 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		config.Env,
 	)
 
+	// set the task execution runtime options
+	opts, err := p.setOptions(config)
+	if err != nil {
+		p.logger.Error("failed to parse options: %v", err)
+		return nil, nil, err
+	}
+
 	// set the task execution environment
 	// no task logging yet; that is setup in the shim
 	env := &shim.Environment{
@@ -238,14 +245,10 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		Memory:       memory,
 		MemoryMax:    memoryMax,
 		CPUBandwidth: bandwidth,
+		OOMScoreAdj:  opts.OOMScoreAdj,
 	}
 
-	// set the task execution runtime options
-	opts, err := p.setOptions(config)
-	if err != nil {
-		p.logger.Error("failed to parse options: %v", err)
-		return nil, nil, err
-	}
+	// set the oom_score_adj
 
 	// what is about to happen
 	p.logger.Info(

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -248,8 +248,6 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		OOMScoreAdj:  opts.OOMScoreAdj,
 	}
 
-	// set the oom_score_adj
-
 	// what is about to happen
 	p.logger.Info(
 		"exec2 runner",


### PR DESCRIPTION
This implements support for setting `oom_score_adj` on a per-task basis. 

See https://github.com/hashicorp/nomad/issues/11087 and https://github.com/hashicorp/nomad/pull/23259 for context. 