### PR TITLE
add newlines to stderr messages and fix error logs

### DIFF
--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -76,7 +76,7 @@ func init() {
 
 		// give ourselves a way to write to the stderr pipe for printing fatal errors
 		debug := func(format string, args ...any) {
-			_, _ = io.WriteString(stderr, fmt.Sprintf(format, args...))
+			_, _ = io.WriteString(stderr, fmt.Sprintf(format+"\n", args...))
 		}
 
 		// use landlock to isolate this process and child processes to the

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -207,7 +207,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	// compute cpu bandwidth value
 	bandwidth, err := resources.Bandwidth(uint64(config.Resources.NomadResources.Cpu.CpuShares))
 	if err != nil {
-		p.logger.Error("failed to compute cpu bandwidth: %w", err)
+		p.logger.Error("failed to compute cpu bandwidth", "error", err)
 		return nil, nil, fmt.Errorf("failed to compute cpu bandwidth: %w", err)
 	}
 
@@ -228,7 +228,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	// set the task execution runtime options
 	opts, err := p.setOptions(config)
 	if err != nil {
-		p.logger.Error("failed to parse options: %v", err)
+		p.logger.Error("failed to parse options", "error", err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Bandwidth can't return an error, so that code is unreachable.

`Failed to parse options` is fairly trivial to hit though by attempting to use `unveil` in a task without having `unveil_by_task = false` in your agent config.

Nomad does not truncate stderr logs between task restarts, so I added a newline to debug statements from the shim command. Without newlines everything gets written to one long line on restart.