### PR TITLE
plugin: make use of Topology object from driver fingerprint

### DIFF
--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -204,7 +204,7 @@ func (e *exe) Stats() *resources.Utilization {
 	userPct, systemPct, totalPct := e.cpu.Percent(usr, system, total)
 
 	specs := resources.GetSpecs()
-	ticks := (.01 * totalPct) * resources.Percent(specs.Ticks()/specs.Cores)
+	ticks := (.01 * totalPct) * resources.Percent(int(specs.Ticks())/specs.Cores)
 
 	return &resources.Utilization{
 		// memory stats

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -32,7 +32,14 @@ func newTestHarness(t *testing.T, pluginConfig *Config) *dtests.DriverHarness {
 	logger := testlog.HCLogger(t)
 	plugin := New(logger).(*Plugin)
 
-	baseConfig := new(base.Config)
+	// set a base config with reasonable topology
+	baseConfig := &base.Config{
+		AgentConfig: &base.AgentConfig{
+			Driver: &base.ClientDriverConfig{
+				Topology: structs.MockWorkstationTopology(),
+			},
+		},
+	}
 
 	// encode and set plugin config
 	must.NoError(t, base.MsgPackEncode(&baseConfig.PluginConfig, pluginConfig))


### PR DESCRIPTION
This PR fixes exec2 to make use of the Topology object created during
driver fingerprinting for computation of CPU resources. This fixes cases
where the naive detection being used before did not work, for example
on ARM CPUs.
