### PR TITLE
[DRAFT] Capture unshare/nsenter output

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,12 +4,24 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-exec2/plugin"
+	"github.com/hashicorp/nomad-driver-exec2/version"
 	"github.com/hashicorp/nomad/plugins"
 )
 
 func main() {
+	printVersion := false
+	flag.BoolVar(&printVersion, "version", printVersion, "print version and exit")
+	flag.Parse()
+	if printVersion {
+		fmt.Println(version.Full())
+		return
+	}
+
 	plugins.Serve(factory)
 }
 

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/resources"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/resources/process"
@@ -79,16 +80,17 @@ type ExecTwo interface {
 }
 
 // New an ExecTwo, an instantiation of the exec2 driver.
-func New(env *Environment, opts *Options) ExecTwo {
+func New(env *Environment, opts *Options, l hclog.Logger) ExecTwo {
 	return &exe{
-		env:  env,
-		opts: opts,
-		cpu:  new(resources.TrackCPU),
+		env:    env,
+		opts:   opts,
+		cpu:    new(resources.TrackCPU),
+		logger: l,
 	}
 }
 
 // Recover an ExecTwo, an already running instance of the execc2 driver.
-func Recover(pid int, env *Environment) ExecTwo {
+func Recover(pid int, env *Environment, l hclog.Logger) ExecTwo {
 	return &exe{
 		pid:     pid,
 		env:     env,
@@ -96,6 +98,7 @@ func Recover(pid int, env *Environment) ExecTwo {
 		waiter:  process.WaitPID(pid, env.TaskDir).Wait(),
 		signals: process.Signals(pid),
 		cpu:     new(resources.TrackCPU),
+		logger:  l,
 	}
 }
 
@@ -109,6 +112,9 @@ type exe struct {
 	cpu     *resources.TrackCPU
 	waiter  process.WaitCh
 	signals process.Signaler
+
+	// comes from New/Recover
+	logger hclog.Logger
 }
 
 func (e *exe) Start(ctx context.Context) error {
@@ -343,8 +349,19 @@ func (e *exe) parameters(uid, gid int) []string {
 func (e *exe) prepare(ctx context.Context, home string, fd, uid, gid int) *exec.Cmd {
 	params := e.parameters(uid, gid)
 	cmd := exec.CommandContext(ctx, params[0], params[1:]...)
-	cmd.Stdout = nil // nsenter and unshare do not log
-	cmd.Stderr = nil // nsenter and unshare do not log
+
+	outfd, err := os.OpenFile(e.env.OutPipe, os.O_WRONLY, 0700)
+	if err != nil {
+		panic(err)
+	}
+	cmd.Stdout = outfd
+
+	errfd, err := os.OpenFile(e.env.OutPipe, os.O_WRONLY, 0700)
+	if err != nil {
+		panic(err)
+	}
+	cmd.Stderr = errfd // nsenter and unshare do not log
+
 	cmd.Env = flatten(e.env.User, home, e.env.Env)
 	cmd.Dir = e.env.TaskDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -352,6 +369,7 @@ func (e *exe) prepare(ctx context.Context, home string, fd, uid, gid int) *exec.
 		CgroupFD:    fd,   // cgroup file descriptor
 		Setpgid:     true, // ignore signals sent to nomad
 	}
+
 	return cmd
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,3 +21,22 @@ var (
 	// VersionMetadata is metadata further describing the build type.
 	VersionMetadata = ""
 )
+
+// Full version number.
+func Full() string {
+	out := "exec2 v" + Version
+
+	if VersionPrerelease != "" {
+		out += "-" + VersionPrerelease
+	}
+
+	if VersionMetadata != "" {
+		out += "+" + VersionMetadata
+	}
+
+	if GitCommit != "" {
+		out += "\nRevision " + GitCommit
+	}
+
+	return out
+}


### PR DESCRIPTION
Fixes #20 

Sorry for the messy commit. I just wanted to get a PoC pushed before I left for the day.

Sorry for commingling 3 changes:

1. Capture stdour/stderr from unshare/nsenter to ensure helpful error messages aren't lost. (The #20 fix)
2. Plumb a logger into the shim, which seems to work and helps in debugging. (Will remove if I don't find any useful log lines to leave in.)
3. Adds a `-version` flag which is totally unrelated, but is helpful when trying to make sure you have the binary you expect. Might be worth building into our task driver plugin machinery because the default "you can't run this binary" output is far less useful than it could be.

I'll get this cleaned up and out of draft.