### PR TITLE
Conditional PWR signal for macos

### DIFF
--- a/pkg/resources/process/signal.go
+++ b/pkg/resources/process/signal.go
@@ -39,8 +39,10 @@ func parse(s string) syscall.Signal {
 		return syscall.SIGTERM
 	case "sigstop":
 		return syscall.SIGSTOP
-	case "sigpwr":
-		return syscall.SIGPWR
+	// Conditional compilation to exclude SIGPWR on macOS
+	// +build !darwin
+    	case "sigpwr":
+        	return syscall.SIGPWR
 	default:
 		// not much else we can do
 		return syscall.Signal(0)


### PR DESCRIPTION
The current PWR signal inclusion causes build errors as its not available on darwin builds.

`# github.com/hashicorp/nomad-driver-exec2/pkg/resources/process ../../../go/pkg/mod/github.com/hashicorp/nomad-driver-exec2@v0.1.0/pkg/resources/process/signal.go:43:18: undefined: syscall.SIGPWR (base)  % go build`

