### PR TITLE
task environment: ignore setting LD_* environment variables

### DIFF
--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -256,9 +256,6 @@ func flatten(user, home string, env map[string]string) []string {
 		"DISPLAY",
 		"COLORTERM",
 		"MAIL",
-
-		// ignore attempts at preloading libs
-		"LD_PRELOAD",
 	})
 
 	env["USER"] = user
@@ -272,8 +269,8 @@ func flatten(user, home string, env map[string]string) []string {
 	// copy environment variables into list form
 	for k, v := range env {
 		switch {
-		case ignoredEnv.Contains(k):
-			continue // skip setting ignored variables
+		case ignoredEnv.Contains(k) || strings.HasPrefix(k, "LD_"):
+			continue // skip setting ignored or dynamic linker variables
 		case v == "":
 			result = append(result, k)
 		default:


### PR DESCRIPTION
This change adds a security enhancement to the exec2 driver by prohibiting users from using LD_* environment variables.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

