### PR TITLE
changelog: add ignoring LD_* environment variables fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 SECURITY:
 
+* Ignore setting LD_* environment variables which can lead to privileged code execution. [GH-76](https://github.com/hashicorp/nomad-driver-exec2/pull/76)
 * Bump dependencies to latest versions. [GH-64](https://github.com/hashicorp/nomad-driver-exec2/pull/64)
 * Bump go to `v1.23.5`. [GH-64](https://github.com/hashicorp/nomad-driver-exec2/pull/65)
 


### PR DESCRIPTION
Adds missing changelog entry for https://github.com/hashicorp/nomad-driver-exec2/pull/76

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

