### PR TITLE
F prepare next release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## UNRELEASED
+
 ## 0.1.1 (October 22, 2025)
 
 * build: Update Nomad version to 1.10.2. [GH-71](https://github.com/hashicorp/nomad-driver-exec2/pull/71)

--- a/version/version.go
+++ b/version/version.go
@@ -11,12 +11,12 @@ var (
 
 	// Version is the main version number that is being run at the moment. It
 	// must conform to the format expected by github.com/hashicorp/go-version.
-	Version = "0.1.1"
+	Version = "0.1.2"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta.1", "rc1.1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 
 	// VersionMetadata is metadata further describing the build type.
 	VersionMetadata = ""


### PR DESCRIPTION
Prepare for next release.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

