### PR TITLE
use `os.Root` when opening or modifying logging FIFOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+SECURITY:
+* Protect logging FIFO from symlink swap attacks (CVE-2026-8052) [GH-87](https://github.com/hashicorp/nomad-driver-exec2/issues/87)
+
+IMPROVEMENTS:
 * build: Update Nomad version to 1.11.1. [GH-81](https://github.com/hashicorp/nomad-driver-exec2/pull/81)
 * build: Update Go to 1.25.3. [GH-81](https://github.com/hashicorp/nomad-driver-exec2/pull/81)
 

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -158,13 +158,26 @@ func (e *exe) Start(ctx context.Context) error {
 }
 
 func (e *exe) fixPipes(uid, gid int) error {
-	if err := os.Chown(e.env.OutPipe, uid, gid); err != nil {
+	if err := fixpipe(e.env.OutPipe, uid, gid); err != nil {
 		return err
 	}
-	if err := os.Chown(e.env.ErrPipe, uid, gid); err != nil {
+	if err := fixpipe(e.env.ErrPipe, uid, gid); err != nil {
 		return err
 	}
 	return nil
+}
+
+func fixpipe(path string, uid, gid int) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("error opening fifo parent directory %q: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	return root.Chown(base, uid, gid)
 }
 
 func (e *exe) PID() int {

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -4,10 +4,10 @@
 package util
 
 import (
+	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/sys/unix"
+	"path/filepath"
 )
 
 // NullCloser returns an implementation of io.WriteCloser that will always
@@ -28,13 +28,31 @@ func (*writeCloser) Close() error {
 //
 // The returned values must be closed by the caller.
 func OpenPipes(stdout, stderr string) (io.WriteCloser, io.WriteCloser, error) {
-	a, err := os.OpenFile(stdout, unix.O_WRONLY, os.ModeNamedPipe)
+	a, err := openpipe(stdout)
 	if err != nil {
 		return nil, nil, err
 	}
-	b, err := os.OpenFile(stderr, unix.O_WRONLY, os.ModeNamedPipe)
+	b, err := openpipe(stderr)
 	if err != nil {
 		return nil, nil, err
 	}
 	return a, b, nil
+}
+
+func openpipe(path string) (io.WriteCloser, error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("error opening fifo parent directory %q: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// also uses O_NOFOLLOW under the hood
+	f, err := root.OpenFile(base, os.O_WRONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error opening writer at %s: %w", path, err)
+	}
+	return f, nil
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -530,6 +530,7 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	if p.config.UnveilDefaults {
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_TASK_DIR"])
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_ALLOC_DIR"])
+		unveil = append(unveil, "rx:"+driverTaskConfig.Env["NOMAD_ALLOC_DIR"]+"/logs")
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_SECRETS_DIR"])
 		parent := filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"])
 		unveil = append(unveil, "rwxc:"+filepath.Join(parent, "tmp"))


### PR DESCRIPTION
If an `exec2` task restarts after another task has swapped its FIFO out for a symlink to a sensitive file, the `exec2` driver will read that contents of that file out into the logs. It will also change the ownership of the file so that it's owned by the dynamic uid/gid of the task.

Use `os.Root` to verify that the FIFO is not traversing out of the allocation log directory, and make the logs directory read-only for the task.

Ref: https://hashicorp.atlassian.net/browse/SECVULN-42948
Ref: https://github.com/hashicorp/nomad-driver-exec2-private/pull/1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

