### PR TITLE
deps: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Copyright IBM Corp. 2024, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      go:
+        patterns:
+          - "*"


### PR DESCRIPTION
We're missing a dependabot config, which means we're getting internal alerts on the small number of dependencies that have vulns, whether or not they actually impact us here.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

