### PR TITLE
support ambient capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FEATURES:
+
+* Added `allow_caps` (plugin config), `cap_add` and `cap_drop` (task config) to support Linux ambient capabilities for tasks. [[GH-96](https://github.com/hashicorp/nomad-driver-exec2/pull/96)]
+
 BREAKING CHANGES:
 
 * Task working directory is now explicitly set to `$NOMAD_TASK_DIR`. Jobs using relative args (e.g. `args = ["local/run.sh"]`) must switch to absolute paths (e.g. `command = "${NOMAD_TASK_DIR}/run.sh"`). [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ plugin "nomad-driver-exec2" {
     unveil_defaults = true
     unveil_paths    = []
     unveil_by_task  = false
+    allow_caps      = ["net_bind_service", "chown", "kill", ...]
   }
 }
 ```
@@ -178,6 +179,24 @@ plugin "nomad-driver-exec2" {
   - `unveil_by_task` - (default: `false`) - enable or disable job submitters to
   specify additional filesystem path access within task config
 
+  - `allow_caps` - (default: 13 Nomad-default capabilities) - an operator
+  allowlist of Linux capability names that tasks on this node are permitted to
+  request. Capability names are case-insensitive and accept all common formats
+  (`net_bind_service`, `NET_BIND_SERVICE`, `CAP_NET_BIND_SERVICE`). Set to `[]`
+  to disallow all capability grants on this node.
+
+  ```hcl
+  # allow tasks to request net_bind_service only
+  allow_caps = ["net_bind_service"]
+
+  # disallow all capability grants
+  allow_caps = []
+  ```
+
+  The default set is:
+  `audit_write`, `chown`, `dac_override`, `fowner`, `fsetid`, `kill`, `mknod`,
+  `net_bind_service`, `setfcap`, `setgid`, `setpcap`, `setuid`, `sys_chroot`.
+
 #### Task Configuration
 
 ##### config
@@ -193,6 +212,8 @@ config {
   args          = ["/etc/os-release"]
   unveil        = ["r:/etc/os-release"]
   oom_score_adj = 500
+  cap_add       = ["net_bind_service"]
+  cap_drop      = []
 }
 ```
 
@@ -208,6 +229,27 @@ config {
 
   - `oom_score_adj` - (optional) - The likelihood of the task being OOM killed,
   must be a positive integer. Defaults to `0`.
+
+  - `cap_add` - (optional) - A list of Linux capability names to add as ambient
+  capabilities for the task process. The effective capability set starts empty;
+  `cap_add` adds to it. Each name must be present in the operator's `allow_caps`
+  plugin config or the task is rejected at start time. Capability names are
+  case-insensitive and accept all common formats (`net_bind_service`,
+  `NET_BIND_SERVICE`, `CAP_NET_BIND_SERVICE`). Defaults to `[]`.
+
+  - `cap_drop` - (optional) - A list of Linux capability names to remove from
+  the set assembled by `cap_add`. Names are normalized the same way as `cap_add`.
+  Useful for dropping a specific capability when `cap_add` was set broadly.
+  Defaults to `[]`.
+
+  ```hcl
+  # grant CAP_NET_BIND_SERVICE so the task can bind port 80 without root
+  cap_add = ["net_bind_service"]
+
+  # grant two caps then selectively revoke one
+  cap_add  = ["net_bind_service", "chown"]
+  cap_drop = ["chown"]
+  ```
 
 ##### cpu
 
@@ -239,6 +281,7 @@ can be used as constraints when authoring jobs.
 ```text
 driver.exec2.unveil.defaults    = true
 driver.exec2.unveil.tasks       = true
+driver.exec2.caps.allowlist     = audit_write,chown,dac_override,fowner,fsetid,kill,mknod,net_bind_service,setfcap,setgid,setpcap,setuid,sys_chroot
 ```
 
 ### Install

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-set/v2 v2.1.0
 	github.com/hashicorp/nomad v1.11.3
+	github.com/moby/sys/capability v0.4.0
 	github.com/shoenig/go-landlock v1.3.1
 	github.com/shoenig/test v1.13.2
 	golang.org/x/sys v0.47.0

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package capabilities
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/moby/sys/capability"
+)
+
+// capNames maps normalized capability names (lowercase, no "cap_" prefix) to
+// their kernel integer values. Built at init time from the moby/sys/capability
+// library's authoritative list — automatically covering every capability the
+// library knows about, with no manual maintenance required.
+//
+// On Linux, ListSupported queries the running kernel for the actual supported
+// set. On other platforms, ListKnown returns the static compiled-in list
+// (used when cross-compiling or running tests on non-Linux).
+var capNames = func() map[string]uintptr {
+	var list []capability.Cap
+	switch runtime.GOOS {
+	case "linux":
+		list, _ = capability.ListSupported()
+	default:
+		list = capability.ListKnown()
+	}
+	m := make(map[string]uintptr, len(list))
+	for _, c := range list {
+		m[c.String()] = uintptr(c)
+	}
+	return m
+}()
+
+// ParseCap resolves a capability name to its kernel integer value. Names are
+// normalized before lookup: case-insensitive and with or without the "cap_"
+// prefix, so "NET_BIND_SERVICE", "cap_net_bind_service", "CAP_NET_BIND_SERVICE",
+// and "net_bind_service" all resolve to the same value.
+func ParseCap(name string) (uintptr, error) {
+	v, ok := capNames[NormalizeCap(name)]
+	if !ok {
+		return 0, fmt.Errorf("unknown capability %q", name)
+	}
+	return v, nil
+}
+
+// Resolve resolves a slice of capability names to their kernel integer values.
+// Returns the first error encountered for an unknown name.
+func Resolve(names []string) ([]uintptr, error) {
+	caps := make([]uintptr, 0, len(names))
+	for _, name := range names {
+		v, err := ParseCap(name)
+		if err != nil {
+			return nil, err
+		}
+		caps = append(caps, v)
+	}
+	return caps, nil
+}
+
+// NormalizeCap lowercases a capability name and strips any "cap_" prefix,
+// accepting all four common formats: "net_bind_service", "NET_BIND_SERVICE",
+// "cap_net_bind_service", "CAP_NET_BIND_SERVICE".
+func NormalizeCap(name string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(name)), "cap_")
+}

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -12,10 +12,7 @@ import (
 )
 
 // capNames maps normalized capability names (lowercase, no "cap_" prefix) to
-// their kernel integer values. Built at init time from the moby/sys/capability
-// library's authoritative list — automatically covering every capability the
-// library knows about, with no manual maintenance required.
-//
+// their kernel integer values.
 // On Linux, ListSupported queries the running kernel for the actual supported
 // set. On other platforms, ListKnown returns the static compiled-in list
 // (used when cross-compiling or running tests on non-Linux).

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+	"golang.org/x/sys/unix"
+)
+
+func TestParseCap(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expVal uintptr
+		expErr string
+	}{
+		{
+			name:   "known cap lowercase",
+			input:  "net_bind_service",
+			expVal: unix.CAP_NET_BIND_SERVICE,
+		},
+		{
+			name:   "known cap uppercase",
+			input:  "NET_BIND_SERVICE",
+			expVal: unix.CAP_NET_BIND_SERVICE,
+		},
+		{
+			name:   "known cap mixed case",
+			input:  "Net_Bind_Service",
+			expVal: unix.CAP_NET_BIND_SERVICE,
+		},
+		{
+			name:   "chown",
+			input:  "chown",
+			expVal: unix.CAP_CHOWN,
+		},
+		{
+			name:   "sys_admin",
+			input:  "sys_admin",
+			expVal: unix.CAP_SYS_ADMIN,
+		},
+		{
+			name:   "checkpoint_restore",
+			input:  "checkpoint_restore",
+			expVal: unix.CAP_CHECKPOINT_RESTORE,
+		},
+		{
+			name:   "cap_ prefix lowercase accepted",
+			input:  "cap_chown",
+			expVal: unix.CAP_CHOWN,
+		},
+		{
+			name:   "CAP_ prefix uppercase accepted",
+			input:  "CAP_NET_BIND_SERVICE",
+			expVal: unix.CAP_NET_BIND_SERVICE,
+		},
+		{
+			name:   "unknown capability",
+			input:  "not_a_real_cap",
+			expErr: `unknown capability "not_a_real_cap"`,
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			expErr: `unknown capability ""`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := ParseCap(tc.input)
+			if tc.expErr != "" {
+				must.EqError(t, err, tc.expErr)
+				must.Eq(t, uintptr(0), val)
+			} else {
+				must.NoError(t, err)
+				must.Eq(t, tc.expVal, val)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("empty slice returns empty", func(t *testing.T) {
+		result, err := Resolve(nil)
+		must.NoError(t, err)
+		must.Len(t, 0, result)
+	})
+
+	t.Run("valid names resolved", func(t *testing.T) {
+		result, err := Resolve([]string{"chown", "net_bind_service"})
+		must.NoError(t, err)
+		must.Len(t, 2, result)
+		must.Eq(t, unix.CAP_CHOWN, result[0])
+		must.Eq(t, unix.CAP_NET_BIND_SERVICE, result[1])
+	})
+
+	t.Run("first unknown name returns error", func(t *testing.T) {
+		_, err := Resolve([]string{"chown", "bad_cap"})
+		must.EqError(t, err, `unknown capability "bad_cap"`)
+	})
+}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -33,6 +33,7 @@ type Options struct {
 	UnveilPaths    []string
 	UnveilDefaults bool
 	OOMScoreAdj    int
+	Capabilities   []string
 	WorkDir        string // working directory for the task; defaults to TaskDir
 }
 
@@ -373,7 +374,8 @@ func (e *exe) parameters(uid, gid int) []string {
 		)
 	}
 
-	// setup unshare for ipc, pid namespaces, and mount propagation
+	// setup unshare for ipc, pid namespaces, mount propagation; uid/gid transition is handled
+	// by the shim itself (after the fork) so it can manage capabilities correctly
 	result = append(result,
 		"unshare",
 		"--ipc",
@@ -383,8 +385,6 @@ func (e *exe) parameters(uid, gid int) []string {
 		"slave",
 		"--fork",
 		"--kill-child=SIGKILL",
-		fmt.Sprintf("--setuid=%d", uid),
-		fmt.Sprintf("--setgid=%d", gid),
 		"--",
 	)
 
@@ -393,6 +393,12 @@ func (e *exe) parameters(uid, gid int) []string {
 	result = append(result, strconv.FormatBool(e.opts.UnveilDefaults))
 	result = append(result, e.env.OutPipe)
 	result = append(result, e.env.ErrPipe)
+	// pass uid and gid so the shim can drop privileges itself (after fork,
+	// before exec) with PR_SET_KEEPCAPS to preserve the ambient capability set
+	result = append(result, strconv.Itoa(uid))
+	result = append(result, strconv.Itoa(gid))
+	// pass capability names as a comma-separated string; empty means no caps
+	result = append(result, strings.Join(e.opts.Capabilities, ","))
 	result = append(result, e.opts.UnveilPaths...)
 	result = append(result, "--")
 

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -10,11 +10,32 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
 
+	"golang.org/x/sys/unix"
+
+	"github.com/hashicorp/nomad-driver-exec2/pkg/capabilities"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/util"
 	"github.com/hashicorp/nomad/helper/subproc"
 )
+
+// capHdr and capData mirror the kernel's __user_cap_header_struct and
+// __user_cap_data_struct used by capset(2). Version 3 (0x20080522) supports
+// capabilities 0–63 via two 32-bit words.
+type capHdr struct {
+	version uint32
+	pid     int32
+}
+
+type capData struct {
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
 
 const (
 	// SubCommand is the first argument to the clone of the nomad agent process
@@ -31,7 +52,7 @@ const (
 	ExitBadLogging = 41
 )
 
-// init is the entrypoint for the 'nomad e2e-shim' invocation of nomad
+// init is the entrypoint for the 'nomad exec2-shim' invocation of nomad
 //
 // The argument format is as follows,
 //
@@ -40,8 +61,11 @@ const (
 // 2. true/false       <- include default unveil paths
 // 3. <stdout path>    <- path to named pipe for standard output
 // 4. <stderr path>    <- path to named pipe for standard error
-// 5. [mode:path, ...] <- list of additional unveil paths
-// 6. --               <- sentinel between following commands
+// 5. <uid>            <- numeric user id for the task process
+// 6. <gid>            <- numeric group id for the task process
+// 7. cap,cap,...      <- comma-separated ambient capability names (empty string if none)
+// 8. [mode:path, ...] <- list of additional unveil paths
+// 9. --               <- sentinel between following commands
 func init() {
 	subproc.Do(SubCommand, func() int {
 		// we need to ignore the stop signal (which is sent to the entire
@@ -50,23 +74,56 @@ func init() {
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs)
 		go func() {
-			<-sigs // do nothing; say alive
+			<-sigs // do nothing; stay alive
 		}()
 
-		if n := len(os.Args); n <= 4 {
-			subproc.Print("failed to invoke e2e-shim with sufficient args: %d", n)
+		if n := len(os.Args); n <= 7 {
+			subproc.Print("failed to invoke exec2-shim with sufficient args: %d", n)
 			return ExitWrongArgs
 		}
 
-		// get the unveil paths and the rest of the command(s) to run
-		// from our command arguments
-		args := os.Args[5:] // chop off 'nomad exec2-shim <defaults>'
 		defaults := os.Args[2] == "true"
 		outPipePath := os.Args[3]
 		errPipePath := os.Args[4]
+		uid, err := strconv.Atoi(os.Args[5])
+		if err != nil {
+			subproc.Print("invalid uid %q: %v", os.Args[5], err)
+			return ExitWrongArgs
+		}
+		gid, err := strconv.Atoi(os.Args[6])
+		if err != nil {
+			subproc.Print("invalid gid %q: %v", os.Args[6], err)
+			return ExitWrongArgs
+		}
+		capsArg := os.Args[7]
+
+		// get the unveil paths and the rest of the command(s) to run
+		// from our command arguments (after uid, gid, and caps args)
+		args := os.Args[8:]
 		paths, commands := split(args)
 		paths = append(paths, "w:"+outPipePath)
 		paths = append(paths, "w:"+errPipePath)
+
+		// resolve capability names to kernel integers before calling dropPrivileges;
+		// this is a pure string-to-integer mapping that requires no privileges
+		var caps []uintptr
+		if capsArg != "" {
+			capNames := strings.Split(capsArg, ",")
+			var capErr error
+			caps, capErr = capabilities.Resolve(capNames)
+			if capErr != nil {
+				subproc.Print("failed to resolve capabilities: %v", capErr)
+				return ExitWrongArgs
+			}
+		}
+
+		// drop privileges conditionally: for non-root tasks, transitions uid/gid;
+		// for tasks with caps, restores them in permitted/effective/inheritable and
+		// raises as ambient so they survive into the task process via exec().
+		if err := dropPrivileges(uid, gid, caps); err != nil {
+			subproc.Print("failed to drop privileges: %v", err)
+			return subproc.ExitFailure
+		}
 
 		stdout, stderr, err := util.OpenPipes(outPipePath, errPipePath)
 		if err != nil {
@@ -94,7 +151,10 @@ func init() {
 			return subproc.ExitNotRunnable
 		}
 
-		// invoke the task command with its args
+		// invoke the task command with its args;
+		// ambient capabilities are already raised in this process and will be
+		// inherited by the child across the exec() boundary automatically
+		
 		// the environment has already been set for us by the exec2 driver;
 		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR
 		cmd := exec.Command(cmdpath, commands[1:]...)
@@ -117,4 +177,94 @@ func init() {
 		_ = os.WriteFile(destination, []byte(strconv.Itoa(code)), 0o644)
 		return code
 	})
+}
+
+// dropPrivileges conditionally drops uid/gid and adds the given capabilities
+// to the ambient set of the shim process so they can be passed to the task process.
+//
+// This collapses the four cases into one function:
+//
+//	uid=0,  caps=[]  → 0 syscalls  (nothing to do)
+//	uid=0,  caps=[…] → steps 4–6  (NO_NEW_PRIVS + CAPSET + AMBIENT_RAISE)
+//	uid≠0,  caps=[]  → steps 2–3  (setresgid + setresuid only)
+//	uid≠0,  caps=[…] → steps 1–7  (full sequence; KEEPCAPS preserves permitted across setresuid)
+func dropPrivileges(uid, gid int, caps []uintptr) error {
+	// All syscalls below are per-thread on Linux (setresuid, setresgid, capset,
+	// prctl). Lock this goroutine to its OS thread so the Go scheduler cannot
+	// migrate it between syscalls, which would cause them to execute on
+	// different threads and silently corrupt capability state.
+	runtime.LockOSThread()
+
+	needDrop := uid != 0      // uid/gid transition only needed for non-root tasks
+	needCaps := len(caps) > 0 // cap management only needed when caps are requested
+
+	// step 1: keep permitted caps across the uid transition; only needed when
+	// both a uid drop AND capability raising are required — if we stay root,
+	// permitted is already full; if no caps are requested, KEEPCAPS is irrelevant
+	if needDrop && needCaps {
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_PRCTL, unix.PR_SET_KEEPCAPS, 1, 0); errno != 0 {
+			return fmt.Errorf("prctl PR_SET_KEEPCAPS=1: %w", errno)
+		}
+	}
+
+	// steps 2+3: drop group and user id; only needed for non-root tasks
+	if needDrop {
+		// group must be dropped before uid (dropping uid first would lose CAP_SETGID)
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_SETRESGID, uintptr(gid), uintptr(gid), uintptr(gid)); errno != 0 {
+			return fmt.Errorf("setresgid %d: %w", gid, errno)
+		}
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_SETRESUID, uintptr(uid), uintptr(uid), uintptr(uid)); errno != 0 {
+			return fmt.Errorf("setresuid %d: %w", uid, errno)
+		}
+	}
+
+	// steps 4–6: manage capabilities when any were requested.
+	if needCaps {
+		// step 4: prevent privilege re-escalation via setuid binaries or file
+		// capabilities on exec; sufficient on its own to block all exec-time
+		// escalation vectors, making bounding-set restriction unnecessary.
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_PRCTL, unix.PR_SET_NO_NEW_PRIVS, 1, 0); errno != 0 {
+			return fmt.Errorf("prctl PR_SET_NO_NEW_PRIVS: %w", errno)
+		}
+
+		// step 5: restore caps in permitted/effective/inheritable then raise as
+		// ambient so they survive into the task process via exec().
+		// For root the permitted set is already full so CAPSET works without KEEPCAPS.
+		hdr := capHdr{version: 0x20080522} // _LINUX_CAPABILITY_VERSION_3
+		data := [2]capData{}
+		for _, c := range caps {
+			idx := c / 32
+			mask := uint32(1) << (c % 32)
+			data[idx].effective |= mask
+			data[idx].permitted |= mask
+			data[idx].inheritable |= mask
+		}
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_CAPSET,
+			uintptr(unsafe.Pointer(&hdr)),
+			uintptr(unsafe.Pointer(&data[0])),
+			0,
+		); errno != 0 {
+			return fmt.Errorf("capset: %w", errno)
+		}
+
+		// step 6: raise each cap as ambient so it is inherited across exec().
+		for _, c := range caps {
+			if _, _, errno := syscall.RawSyscall6(syscall.SYS_PRCTL,
+				unix.PR_CAP_AMBIENT,
+				unix.PR_CAP_AMBIENT_RAISE,
+				c, 0, 0, 0,
+			); errno != 0 {
+				return fmt.Errorf("prctl PR_CAP_AMBIENT_RAISE %d: %w", c, errno)
+			}
+		}
+	}
+
+	// step 7: clear KEEPCAPS — mirrors step 1; only set when needDrop && needCaps
+	if needDrop && needCaps {
+		if _, _, errno := syscall.RawSyscall(syscall.SYS_PRCTL, unix.PR_SET_KEEPCAPS, 0, 0); errno != 0 {
+			return fmt.Errorf("prctl PR_SET_KEEPCAPS=0: %w", errno)
+		}
+	}
+
+	return nil
 }

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -18,6 +18,11 @@ const (
 	name          = "exec2"
 	version       = "v2.0.0"
 	handleVersion = 1
+
+	// allowCapsDefault is the default set of Linux capabilities the exec2
+	// driver permits tasks to request, expressed as an HCL literal for use
+	// in hclspec.NewLiteral.
+	allowCapsDefault = `["audit_write","chown","dac_override","fowner","fsetid","kill","mknod","net_bind_service","setfcap","setgid","setpcap","setuid","sys_chroot"]`
 )
 
 // PluginID is the exec plugin metadata registered in the plugin
@@ -52,6 +57,10 @@ var driverConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		hclspec.NewLiteral("false"),
 	),
 	"unveil_paths": hclspec.NewAttr("unveil_paths", "list(string)", false),
+	"allow_caps": hclspec.NewDefault(
+		hclspec.NewAttr("allow_caps", "list(string)", false),
+		hclspec.NewLiteral(allowCapsDefault),
+	),
 })
 
 // taskConfigSpec is the HCL configuration set for the task on the jobspec
@@ -60,6 +69,8 @@ var taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 	"args":          hclspec.NewAttr("args", "list(string)", false),
 	"unveil":        hclspec.NewAttr("unveil", "list(string)", false),
 	"oom_score_adj": hclspec.NewAttr("oom_score_adj", "number", false),
+	"cap_add":       hclspec.NewAttr("cap_add", "list(string)", false),
+	"cap_drop":      hclspec.NewAttr("cap_drop", "list(string)", false),
 	"work_dir":      hclspec.NewAttr("work_dir", "string", false),
 })
 
@@ -83,6 +94,7 @@ type Config struct {
 	UnveilDefaults bool     `codec:"unveil_defaults"`
 	UnveilPaths    []string `codec:"unveil_paths"`
 	UnveilByTask   bool     `codec:"unveil_by_task"`
+	AllowCaps      []string `codec:"allow_caps"`
 }
 
 // TaskConfig represents the exec2 driver task configuration that gets set in
@@ -92,5 +104,7 @@ type TaskConfig struct {
 	Args        []string `codec:"args"`
 	Unveil      []string `codec:"unveil"`
 	OOMScoreAdj int      `codec:"oom_score_adj"`
+	CapAdd      []string `codec:"cap_add"`
+	CapDrop     []string `codec:"cap_drop"`
 	WorkDir     string   `codec:"work_dir"`
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,9 +11,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	set "github.com/hashicorp/go-set/v2"
+	caps "github.com/hashicorp/nomad-driver-exec2/pkg/capabilities"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/resources"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/shim"
 	"github.com/hashicorp/nomad-driver-exec2/pkg/task"
@@ -92,11 +95,16 @@ func (p *Plugin) SetConfig(c *base.Config) error {
 	p.compute = c.AgentConfig.Compute()
 	resources.SetSpecs(p.compute)
 
+	// validate that every capability name in allow_caps is a known Linux capability
+	for _, cap := range config.AllowCaps {
+		if _, err := caps.ParseCap(cap); err != nil {
+			return fmt.Errorf("invalid capability %q in allow_caps: %w", cap, err)
+		}
+	}
+
 	// Set the decoded config object
 	p.config = &config
 
-	// currently not much to validate on the plugin config, but if there was
-	// that step would go here
 	return nil
 }
 
@@ -174,6 +182,7 @@ func (p *Plugin) doFingerprint(find lookupFunc) *drivers.Fingerprint {
 		Attributes: map[string]*structs.Attribute{
 			"driver.exec2.unveil.tasks":    structs.NewBoolAttribute(p.config.UnveilByTask),
 			"driver.exec2.unveil.defaults": structs.NewBoolAttribute(p.config.UnveilDefaults),
+			"driver.exec2.caps.allowlist":  structs.NewStringAttribute(strings.Join(p.config.AllowCaps, ",")),
 		},
 	}
 }
@@ -272,6 +281,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		"unveil_paths", opts.UnveilPaths,
 		"unveil_defaults", opts.UnveilDefaults,
 		"oom_score_adj", opts.OOMScoreAdj,
+		"capabilities", opts.Capabilities,
 	)
 
 	// create the runner and start it
@@ -586,12 +596,32 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		unveil = append(unveil, taskConfig.Unveil...)
 	}
 
+	// Compute the effective capability set:
+	//   1. start with cap_add (normalized)
+	//   2. remove anything in cap_drop (normalized)
+	//   3. every remaining cap must be present in the operator allow_caps list
+	//
+	// Cap names are normalized throughout so "NET_BIND_SERVICE",
+	// "cap_net_bind_service", and "net_bind_service" all compare equal.
+	effectiveCaps := set.FromFunc(taskConfig.CapAdd, caps.NormalizeCap)
+	effectiveCaps.RemoveSlice(set.FromFunc(taskConfig.CapDrop, caps.NormalizeCap).Slice())
+
+	if effectiveCaps.Size() > 0 {
+		allowed := set.FromFunc(p.config.AllowCaps, caps.NormalizeCap)
+		for _, c := range effectiveCaps.Slice() {
+			if !allowed.Contains(c) {
+				return nil, fmt.Errorf("task requested capability %q not in driver allow_caps", c)
+			}
+		}
+	}
+
 	return &shim.Options{
 		Command:        taskConfig.Command,
 		Arguments:      taskConfig.Args,
 		UnveilPaths:    unveil,
 		UnveilDefaults: p.config.UnveilDefaults,
 		OOMScoreAdj:    taskConfig.OOMScoreAdj,
+		Capabilities:   effectiveCaps.Slice(),
 		WorkDir:        taskConfig.WorkDir,
 	}, nil
 }

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -153,12 +153,15 @@ func TestFunctional_cases(t *testing.T) {
 		command string
 		args    []string
 		unveil  []string
+		capAdd  []string
+		capDrop []string
 		workDir string // relative or absolute path; empty defaults to NOMAD_TASK_DIR
 
 		// plugin config
 		unveilDefaults bool
 		unveilByTask   bool
 		unveilPaths    []string
+		allowCaps      []string
 
 		// expectations
 		exp      *drivers.ExitResult
@@ -453,6 +456,76 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`\w+/tmp/tmp\.\w+`),
 		},
+		// cap_add: a granted capability is present as ambient in the task process.
+		// We read the ambient cap bitmask from /proc/self/status and verify it is
+		// non-zero. CAP_NET_BIND_SERVICE is bit 10 → bitmask 0x0000000000000400.
+		// /proc is unveiled so the PID-namespace /proc/self is reachable.
+		{
+			name:           "cap_add ambient cap is raised in task",
+			user:           "nomad-80000",
+			command:        "sh",
+			args:           []string{"-c", "grep CapAmb /proc/self/status"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			allowCaps:      []string{"net_bind_service"},
+			capAdd:         []string{"net_bind_service"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			// match any non-zero hex value in the CapAmb field
+			stdoutRe: regexp.MustCompile(`CapAmb:\s+[0-9a-f]*[1-9a-f][0-9a-f]*`),
+		},
+		{
+			name:           "cap_add ambient cap is raised in root task",
+			user:           "root",
+			command:        "sh",
+			args:           []string{"-c", "grep CapAmb /proc/self/status"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			allowCaps:      []string{"net_bind_service"},
+			capAdd:         []string{"net_bind_service"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`CapAmb:\s+[0-9a-f]*[1-9a-f][0-9a-f]*`),
+		},
+		// no cap_add means CapAmb must be all-zeroes; guards against accidental raises.
+		{
+			name:           "no cap_add means CapAmb is zero",
+			user:           "nomad-80000",
+			command:        "sh",
+			args:           []string{"-c", "grep CapAmb /proc/self/status"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			allowCaps:      []string{"net_bind_service"},
+			// capAdd intentionally omitted — no caps requested
+			exp:      &drivers.ExitResult{ExitCode: 0},
+			stdoutRe: regexp.MustCompile(`CapAmb:\s+0000000000000000`),
+		},
+		// cap names in mixed casing with CAP_ prefix must be accepted when
+		// allow_caps holds the lowercase unprefixed equivalent.
+		{
+			name:           "cap_add normalized casing accepted",
+			user:           "nomad-80000",
+			command:        "sh",
+			args:           []string{"-c", "grep CapAmb /proc/self/status"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			allowCaps:      []string{"net_bind_service"},     // lowercase, no prefix
+			capAdd:         []string{"CAP_NET_BIND_SERVICE"}, // uppercase, with prefix
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`CapAmb:\s+[0-9a-f]*[1-9a-f][0-9a-f]*`),
+		},
+		// cap_drop removes a cap that cap_add granted; effective set must be empty.
+		{
+			name:           "cap_drop removes cap added by cap_add",
+			user:           "nomad-80000",
+			command:        "sh",
+			args:           []string{"-c", "grep CapAmb /proc/self/status"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			allowCaps:      []string{"net_bind_service"},
+			capAdd:         []string{"net_bind_service"},
+			capDrop:        []string{"net_bind_service"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`CapAmb:\s+0000000000000000`),
+    },
 		// cwd is the task directory (not in a veiled parent path)
 		{
 			name:           "cwd is task dir",
@@ -503,11 +576,12 @@ func TestFunctional_cases(t *testing.T) {
 				UnveilDefaults: tc.unveilDefaults,
 				UnveilByTask:   tc.unveilByTask,
 				UnveilPaths:    tc.unveilPaths,
+				AllowCaps:      tc.allowCaps,
 			}
 
 			allocID := uuid.Generate()
 			taskName := "test_cases_" + uuid.Short()
-
+	
 			task := &drivers.TaskConfig{
 				User:      tc.user,
 				ID:        uuid.Generate(),
@@ -515,16 +589,18 @@ func TestFunctional_cases(t *testing.T) {
 				AllocID:   allocID,
 				Resources: basicResources(allocID, taskName),
 			}
-
+	
 			harness := newTestHarness(t, pluginConfig)
 			harness.MakeTaskCgroup(task.AllocID, task.Name)
 			cleanup := harness.MkAllocDir(task, true)
 			defer cleanup()
-
+	
 			taskConfig := &TaskConfig{
 				Command: tc.command,
 				Args:    tc.args,
 				Unveil:  tc.unveil,
+				CapAdd:  tc.capAdd,
+				CapDrop: tc.capDrop,
 				WorkDir: tc.workDir,
 			}
 
@@ -609,6 +685,7 @@ func Test_doFingerprint_normal(t *testing.T) {
 	p.config = &Config{
 		UnveilByTask:   true,
 		UnveilDefaults: true,
+		AllowCaps:      []string{"net_bind_service", "chown"},
 	}
 	fp := p.doFingerprint(exec.LookPath)
 
@@ -617,6 +694,7 @@ func Test_doFingerprint_normal(t *testing.T) {
 	must.Eq(t, map[string]*dstructs.Attribute{
 		"driver.exec2.unveil.tasks":    dstructs.NewBoolAttribute(true),
 		"driver.exec2.unveil.defaults": dstructs.NewBoolAttribute(true),
+		"driver.exec2.caps.allowlist":  dstructs.NewStringAttribute("net_bind_service,chown"),
 	}, fp.Attributes)
 }
 
@@ -676,4 +754,70 @@ func Test_tools(t *testing.T) {
 		must.NoError(t, err)
 		t.Log("path to nsenter is: " + path)
 	})
+}
+
+// TestSetConfig_AllowCaps_Validation verifies that SetConfig rejects unknown
+// capability names in the allow_caps plugin configuration.
+func TestSetConfig_AllowCaps_Validation(t *testing.T) {
+	ci.Parallel(t)
+
+	logger := testlog.HCLogger(t)
+	p := New(logger).(*Plugin)
+
+	baseConfig := &base.Config{
+		AgentConfig: &base.AgentConfig{
+			Driver: &base.ClientDriverConfig{
+				Topology: structs.MockWorkstationTopology(),
+			},
+		},
+	}
+
+	invalidConfig := &Config{
+		UnveilDefaults: true,
+		AllowCaps:      []string{"net_bind_service", "not_a_real_capability"},
+	}
+	must.NoError(t, base.MsgPackEncode(&baseConfig.PluginConfig, invalidConfig))
+
+	err := p.SetConfig(baseConfig)
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "not_a_real_capability")
+}
+
+// TestFunctional_cap_add_not_allowed verifies that a task requesting a
+// capability not present in the plugin allow_caps list is rejected at start
+// time with a descriptive error.
+func TestFunctional_cap_add_not_allowed(t *testing.T) {
+	ctests.RequireRoot(t)
+	ci.Parallel(t)
+
+	pluginConfig := &Config{
+		UnveilDefaults: true,
+		AllowCaps:      []string{}, // empty: no caps permitted
+	}
+
+	taskConfig := &TaskConfig{
+		Command: "env",
+		CapAdd:  []string{"net_bind_service"},
+	}
+
+	allocID := uuid.Generate()
+	taskName := "test_caps_not_allowed_" + uuid.Short()
+
+	task := &drivers.TaskConfig{
+		User:      "nomad-80000",
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		AllocID:   allocID,
+		Resources: basicResources(allocID, taskName),
+	}
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
+
+	harness := newTestHarness(t, pluginConfig)
+	harness.MakeTaskCgroup(task.AllocID, task.Name)
+	cleanup := harness.MkAllocDir(task, true)
+	defer cleanup()
+
+	_, _, err := harness.StartTask(task)
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "net_bind_service")
 }


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/79

_**Summary**_

Adds two new configuration fields  `allow_caps ` and `alloc_caps` that let operators and job authors selectively grant Linux ambient capabilities to exec2 tasks. This is the capability model used by Nomad's built-in exec driver, now brought to exec2.

The primary use case is letting a non-root dynamic workload user bind a privileged port (e.g. port 80) via CAP_NET_BIND_SERVICE without running as root — something that was structurally impossible before this change.

_**Before This Change**_

**The problem**
exec2 ran every task through a three-level process chain, with unshare --setuid responsible for the uid/gid transition:

```
Nomad agent (root)
  └─ unshare --setuid=80000 --setgid=80000 --ipc --pid ...
       └─ nomad exec2-shim <args>      ← already running as uid 80000
            └─ user command             ← CapAmb: 0000000000000000 always
```

**The kernel enforces a hard rule:** any call to `setresuid()` with a new non-zero real UID clears the entire ambient capability set. Because unshare --setuid calls setresuid() internally as part of its own uid transition, the ambient set was always wiped before the shim even started. There was no way to recover it.

_**Root cause**_

Kernel rule from [capabilities(7)](https://man7.org/linux/man-pages/man7/capabilities.7.html): A call to setresuid(nonzero) unconditionally clears the entire ambient set. The only way to preserve permitted capabilities across that transition is `prctl(PR_SET_KEEPCAPS, 1)` set before the uid change  which `unshare` does not do.

_**The Fix — Move the uid/gid Transition Into the Shim**_

`unshare --setuid` and `--setgid` are removed. The shim now receives the target uid, gid, and requested capability names as argv slots, and performs the uid/gid transition itself using the sequence prescribed by `capabilities(7)`:

```
Nomad agent (root)
  └─ unshare --ipc --pid --mount-proc --fork   ← no --setuid/--setgid
       └─ nomad exec2-shim ... uid gid caps ... ← still root at entry
            │  1. prctl(PR_SET_KEEPCAPS, 1)     ← preserve permitted across setresuid
            │  2. setresgid(gid)
            │  3. setresuid(uid)                ← now uid 80000, permitted still intact
            │  4. CAPSET(caps)                  ← restore in permitted+effective+inheritable
            │  5. prctl(PR_CAP_AMBIENT_RAISE)   ← raise as ambient
            │  6. prctl(PR_SET_KEEPCAPS, 0)     ← clean up
            └─ user command                     ← CapAmb: 0000000000000400 ✓
```

_**The dropPrivileges function — four-case matrix**_

uid | caps requested | Steps executed | Syscall count
-- | -- | -- | --
0 (root) | none | nothing | 0
0 (root) | [net_bind_service] | CAPSET + AMBIENT_RAISE (steps 4–5 only; permitted already full for root) | 2+n
80000 (non-root) | none | setresgid + setresuid (steps 2–3 only) | 2
80000 (non-root) | [net_bind_service] | Full sequence steps 1–6 (KEEPCAPS bridges the uid transition) | 4+2n

_**Argv protocol change**_

Slot | Before | After
-- | -- | --
argv[0..4] | binary, subcommand, defaults, stdout, stderr | same
argv[5] | unveil paths start here | <uid> (new)
argv[6] | -- sentinel | <gid> (new)
argv[7] | user command | cap,cap,... (new; "" if none)
argv[8+] | user args | unveil paths, --, user command, args (shifted +3)

_**New Configuration Fields**_

Field | Level | Type | Default | Description
-- | -- | -- | -- | --
allow_caps | Plugin config (operator) | list(string) | 13 Nomad-default caps | Operator allowlist. Tasks can only request capabilities present in this list.
alloc_caps | Task config (job author) | list(string) | [] (none) | Capabilities to grant as ambient to the task process. Must be a subset of allow_caps.

_**Capability names are case-insensitive and accept all four common formats:**_

```
net_bind_service        # lowercase, no prefix  ← canonical
NET_BIND_SERVICE        # uppercase, no prefix
cap_net_bind_service    # lowercase, with prefix
CAP_NET_BIND_SERVICE    # uppercase, with prefix  ← also accepted
```

_**Default allow_caps (13 caps — matches Nomad exec driver)**_
```
audit_write, chown, dac_override, fowner, fsetid, kill, mknod,
net_bind_service, setfcap, setgid, setpcap, setuid, sys_chroot
```

**_Testing_**
<details>
1) verify alloc_caps works end-to-end:

```
job "caps-test" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "check-caps" {
      driver = "exec2"

      config {
        command = "sh"
        args    = ["-c", "grep CapAmb /proc/self/status"]

        # alloc_caps: grant CAP_NET_BIND_SERVICE as an ambient capability.
        # The kernel applies this after the uid/gid drop inside unshare,
        # so the unprivileged dynamic workload user inherits it.
        alloc_caps = ["net_bind_service"]

        # unveil /proc so the sandboxed task can read /proc/self/status
        unveil = ["r:/proc"]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```
**Result:**
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad job status caps-test
ID            = caps-test
Name          = caps-test
Submit Date   = 2026-07-31T15:11:40+05:30
Type          = batch
Priority      = 50
Datacenters   = *
Namespace     = default
Node Pool     = default
Status        = dead
Periodic      = false
Parameterized = false

Summary
Task Group  Queued  Starting  Running  Failed  Complete  Lost  Unknown
group       0       0         0        0       1         0     0

Allocations
ID        Node ID   Task Group  Version  Desired  Status    Created    Modified
31b04c09  8b821ad6  group       0        run      complete  6m21s ago  6m18s ago

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs 31b04c09
CapAmb: 0000000000000400
```

2) net_bind_service lets a task bind port 80

```
job "port80" {
  type = "service"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    network {
      mode = "host"
      # Port 80 — requires CAP_NET_BIND_SERVICE for non-root processes
      port "http" { static = 80 }
    }

    task "server" {
      driver = "exec2"

      config {
        command = "python3"
        args    = ["-m", "http.server", "80", "--directory", "${NOMAD_TASK_DIR}"]

        # Without this, python3 (running as nomad-XXXXX, non-root) would fail:
        # OSError: [Errno 13] Permission denied (binding port 80)
        #
        # With this, CAP_NET_BIND_SERVICE is raised as an ambient capability,
        # so the kernel allows binding the privileged port.
        alloc_caps = ["net_bind_service"]
      }

      resources {
        cpu    = 200
        memory = 64
      }
    }
  }
}
```

**Result:** 
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc status f6fc691c
ID                  = f6fc691c-bc3c-aef1-ea4c-ed226ad39538
Eval ID             = 3b8fe0e7
Name                = port80.group[0]
Node ID             = ffef0122
Node Name           = podman-dev
Job ID              = port80
Job Version         = 0
Client Status       = running
Client Description  = Tasks are running
Desired Status      = run
Desired Description = <none>
Created             = 43s ago
Modified            = 32s ago
Deployment ID       = 80505c44
Deployment Health   = healthy

Allocation Addresses (mode = "host"):
Label  Dynamic  Address
*http  yes      127.0.0.1:80

Task "server" is "running"
Task Resources:
CPU        Memory         Disk     Addresses
0/200 MHz  61 MiB/64 MiB  300 MiB  

Task Events:
Started At     = 2026-07-31T10:05:58Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-07-31T15:35:58+05:30  Started     Task started by client
2026-07-31T15:35:58+05:30  Task Setup  Building Task Directory
2026-07-31T15:35:58+05:30  Received    Task received by client


riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ curl -s http://localhost:80/
<!DOCTYPE HTML>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>
```

3) Capability not in allow_caps:

```
server {
  enabled          = true
  bootstrap_expect = 1
}

client {
  enabled = true
  options = {
    "fingerprint.denylist" = "env_aws,env_gce,env_azure,env_digitalocean"
  }
}

plugin "nomad-driver-exec2" {
  config {
    unveil_defaults = true
    unveil_by_task  = true
    # Empty allowlist: operator disallows all capability grants.
    # Any task that specifies alloc_caps will be rejected at start time.
    allow_caps = []
  }
}
```

Result:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc status 91f4baf2
ID                  = 91f4baf2-70e2-13f3-8818-33b7a6d4c5b2
Eval ID             = 5dc338dc
Name                = caps-test.group[0]
Node ID             = d99708db
Node Name           = podman-dev
Job ID              = caps-test
Job Version         = 0
Client Status       = failed
Client Description  = Failed tasks
Desired Status      = run
Desired Description = <none>
Created             = 1m13s ago
Modified            = 1m9s ago

Task "check-caps" is "dead"
Task Resources:
CPU      Memory  Disk     Addresses
100 MHz  32 MiB  300 MiB  

Task Events:
Started At     = N/A
Finished At    = 2026-07-31T09:58:57Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type            Description
2026-07-31T15:28:57+05:30  Not Restarting  Policy allows no restarts
2026-07-31T15:28:57+05:30  Driver Failure  rpc error: code = Unknown desc = task requested capability "net_bind_service" not in driver allow_caps
2026-07-31T15:28:57+05:30  Task Setup      Building Task Directory
2026-07-31T15:28:57+05:30  Received        Task received by client
```





</details>







<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

