### PR TITLE
fix: tasks are started with a cwd in a veiled directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+
+* Task working directory is now explicitly set to `$NOMAD_TASK_DIR`. Jobs using relative args (e.g. `args = ["local/run.sh"]`) must switch to absolute paths (e.g. `command = "${NOMAD_TASK_DIR}/run.sh"`). [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
+
+IMPROVEMENTS:
+
+* Added optional `work_dir` task config field (absolute path) to override the default CWD. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
+
 BUG FIXES:
 
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 
-* Added optional `work_dir` task config field (absolute path) to override the default CWD. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
+* Added optional `work_dir` task config field to override the default CWD. Accepts an absolute or task-relative path. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 
-* Added optional `work_dir` task config field to override the default CWD. Accepts an absolute or task-relative path. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
+* Added optional `work_dir` task config field to override the default CWD. Accepts an absolute path or a path relative to the task directory parent. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
 
 BUG FIXES:
 

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -291,6 +291,7 @@ func TestBasic_ProcessNamespace(t *testing.T) {
 	defer purge(t, ctx, "ps")()
 
 	_ = run(t, ctx, "nomad", "job", "run", "./jobs/ps.hcl")
+	wait(t, ctx, "ps")
 
 	logs := logs2(t, ctx, "ps", "ps")
 	lines := strings.Split(logs, "\n") // header + shim + ps

--- a/e2e/jobs/java.hcl
+++ b/e2e/jobs/java.hcl
@@ -41,7 +41,7 @@ public class Test {
 
       config {
         command = "${var.javabin}/javac"
-        args    = ["-d", "${NOMAD_ALLOC_DIR}", "local/Test.java"]
+        args    = ["-d", "${NOMAD_ALLOC_DIR}", "${NOMAD_TASK_DIR}/Test.java"]
         unveil  = ["r:${var.etcjava}"]
       }
 

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -33,6 +33,7 @@ type Options struct {
 	UnveilPaths    []string
 	UnveilDefaults bool
 	OOMScoreAdj    int
+	WorkDir        string // working directory for the task; defaults to TaskDir
 }
 
 // Environment represents runtime configuration.
@@ -42,6 +43,7 @@ type Environment struct {
 	ErrPipe      string            // io pipe path for stderr
 	Env          map[string]string // environment variables
 	TaskDir      string            // task directory
+	WorkDir      string            // working directory for the task; defaults to TaskDir
 	Cgroup       string            // task cgroup path
 	Net          string            // allocation network namespace path
 	Memory       uint64            // memory in megabytes
@@ -293,7 +295,7 @@ func (e *exe) writeCG(file, content string) error {
 	return f.Close()
 }
 
-func flatten(user, home string, env map[string]string) []string {
+func flatten(user, home, workDir string, env map[string]string) []string {
 	result := make([]string, 0, len(env))
 
 	// override and remove some variables
@@ -313,6 +315,13 @@ func flatten(user, home string, env map[string]string) []string {
 	parent := filepath.Dir(env["NOMAD_TASK_DIR"])
 	tmp := filepath.Join(parent, "tmp")
 	env["TMPDIR"] = tmp
+
+	// set the working directory; defaults to NOMAD_TASK_DIR when not overridden
+	if workDir != "" {
+		env["NOMAD_WORK_DIR"] = workDir
+	} else {
+		env["NOMAD_WORK_DIR"] = env["NOMAD_TASK_DIR"]
+	}
 
 	// copy environment variables into list form
 	for k, v := range env {
@@ -425,8 +434,13 @@ func (e *exe) prepare(ctx context.Context, home string, fd, uid, gid int) (*exec
 	cmd.Stderr = errfd
 	e.errfd = errfd
 
-	cmd.Env = flatten(e.env.User, home, e.env.Env)
-	cmd.Dir = e.env.TaskDir
+	cmd.Env = flatten(e.env.User, home, e.env.WorkDir, e.env.Env)
+	// use work_dir when set, otherwise fall back to the task directory
+	if e.env.WorkDir != "" {
+		cmd.Dir = e.env.WorkDir
+	} else {
+		cmd.Dir = e.env.TaskDir
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		UseCgroupFD: true, // clone directly into cgroup
 		CgroupFD:    fd,   // cgroup file descriptor

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -95,8 +95,10 @@ func init() {
 		}
 
 		// invoke the task command with its args
-		// the environment has already been set for us by the exec2 driver
+		// the environment has already been set for us by the exec2 driver;
+		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR
 		cmd := exec.Command(cmdpath, commands[1:]...)
+		cmd.Dir = os.Getenv("NOMAD_WORK_DIR")
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -60,6 +60,7 @@ var taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 	"args":          hclspec.NewAttr("args", "list(string)", false),
 	"unveil":        hclspec.NewAttr("unveil", "list(string)", false),
 	"oom_score_adj": hclspec.NewAttr("oom_score_adj", "number", false),
+	"work_dir":      hclspec.NewAttr("work_dir", "string", false),
 })
 
 var capabilities = &drivers.Capabilities{
@@ -91,4 +92,5 @@ type TaskConfig struct {
 	Args        []string `codec:"args"`
 	Unveil      []string `codec:"unveil"`
 	OOMScoreAdj int      `codec:"oom_score_adj"`
+	WorkDir     string   `codec:"work_dir"`
 }

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -51,10 +51,6 @@ var driverConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		hclspec.NewAttr("unveil_by_task", "bool", false),
 		hclspec.NewLiteral("false"),
 	),
-	"work_dir_by_task": hclspec.NewDefault(
-		hclspec.NewAttr("work_dir_by_task", "bool", false),
-		hclspec.NewLiteral("false"),
-	),
 	"unveil_paths": hclspec.NewAttr("unveil_paths", "list(string)", false),
 })
 
@@ -84,10 +80,9 @@ var capabilities = &drivers.Capabilities{
 // Config represents the exec2 driver plugin configuration that gets set in
 // the Nomad client configuration file.
 type Config struct {
-	UnveilDefaults  bool     `codec:"unveil_defaults"`
-	UnveilPaths     []string `codec:"unveil_paths"`
-	UnveilByTask    bool     `codec:"unveil_by_task"`
-	WorkDirByTask   bool     `codec:"work_dir_by_task"`
+	UnveilDefaults bool     `codec:"unveil_defaults"`
+	UnveilPaths    []string `codec:"unveil_paths"`
+	UnveilByTask   bool     `codec:"unveil_by_task"`
 }
 
 // TaskConfig represents the exec2 driver task configuration that gets set in

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -51,6 +51,10 @@ var driverConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		hclspec.NewAttr("unveil_by_task", "bool", false),
 		hclspec.NewLiteral("false"),
 	),
+	"work_dir_by_task": hclspec.NewDefault(
+		hclspec.NewAttr("work_dir_by_task", "bool", false),
+		hclspec.NewLiteral("false"),
+	),
 	"unveil_paths": hclspec.NewAttr("unveil_paths", "list(string)", false),
 })
 
@@ -80,9 +84,10 @@ var capabilities = &drivers.Capabilities{
 // Config represents the exec2 driver plugin configuration that gets set in
 // the Nomad client configuration file.
 type Config struct {
-	UnveilDefaults bool     `codec:"unveil_defaults"`
-	UnveilPaths    []string `codec:"unveil_paths"`
-	UnveilByTask   bool     `codec:"unveil_by_task"`
+	UnveilDefaults  bool     `codec:"unveil_defaults"`
+	UnveilPaths     []string `codec:"unveil_paths"`
+	UnveilByTask    bool     `codec:"unveil_by_task"`
+	WorkDirByTask   bool     `codec:"work_dir_by_task"`
 }
 
 // TaskConfig represents the exec2 driver task configuration that gets set in

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -561,11 +560,14 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	// is required. work_dir outside the alloc directory expands the filesystem
 	// surface, so it uses the same unveil_by_task gate as task-specified
 	// unveil paths.
+	//
+	// childEscapesParentDir uses os.OpenRoot so the kernel enforces the
+	// boundary — symlinks pointing outside the alloc root cannot bypass this.
 	if taskConfig.WorkDir != "" {
 		// alloc root is the grandparent of NOMAD_TASK_DIR:
 		// NOMAD_TASK_DIR = <alloc>/<task>/local  →  alloc root = <alloc>
 		allocRoot := filepath.Dir(filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"]))
-		if !withinDir(allocRoot, taskConfig.WorkDir) {
+		if err := childEscapesParentDir(allocRoot, taskConfig.WorkDir); err != nil {
 			if !p.config.UnveilByTask {
 				return nil, fmt.Errorf("task set work_dir outside sandbox but driver config does not allow this")
 			}
@@ -592,10 +594,27 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	}, nil
 }
 
-// withinDir reports whether path is equal to dir or nested inside it.
-// It uses filepath.Rel so separator arithmetic is handled by the standard
-// library — a relative result starting with ".." means path is outside dir.
-func withinDir(dir, path string) bool {
-	rel, err := filepath.Rel(dir, path)
-	return err == nil && !strings.HasPrefix(rel, "..")
+// childEscapesParentDir reports whether child escapes parent by returning a
+// non-nil error. Uses os.OpenRoot so that the kernel enforces the sandbox
+// boundary, a symlink inside parent that points outside it cannot bypass
+// this check. This mirrors the escapingfs.ChildEscapesParentDir helper
+// introduced in Nomad v2.0.5
+func childEscapesParentDir(parent, child string) error {
+	if filepath.IsAbs(child) {
+		var err error
+		child, err = filepath.Rel(parent, child)
+		if err != nil {
+			return err
+		}
+	}
+	root, err := os.OpenRoot(parent)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	_, err = root.Stat(child)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -528,9 +528,13 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		return nil, fmt.Errorf("failed to decode driver task config: %w", err)
 	}
 
-	// work_dir must be an absolute path when set
+	// if work_dir is set, resolve a relative path against the parent of
+	// NOMAD_TASK_DIR (the task working directory: <alloc>/<task-name>/) so
+	// that job authors can write portable relative paths like "local/subdir"
+	// without needing to know the runtime absolute allocation path.
 	if taskConfig.WorkDir != "" && !filepath.IsAbs(taskConfig.WorkDir) {
-		return nil, fmt.Errorf("work_dir must be an absolute path: %q", taskConfig.WorkDir)
+		taskParent := filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"])
+		taskConfig.WorkDir = filepath.Join(taskParent, taskConfig.WorkDir)
 	}
 
 	// combine paths to unveil from plugin config, task config (if enabled),
@@ -551,7 +555,12 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	// if work_dir is set, it must be accessible under Landlock — the task
 	// cannot chdir into a veiled directory. Auto-unveil it with rwxc so the
 	// task can read, write, execute, and create files there.
+	// work_dir_by_task must be enabled in the plugin config to allow job
+	// authors to set an arbitrary working directory.
 	if taskConfig.WorkDir != "" {
+		if !p.config.WorkDirByTask {
+			return nil, fmt.Errorf("task set work_dir but driver config does not allow this")
+		}
 		unveil = append(unveil, "rwxc:"+taskConfig.WorkDir)
 	}
 
@@ -573,3 +582,4 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		WorkDir:        taskConfig.WorkDir,
 	}, nil
 }
+

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -253,6 +253,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 		ErrPipe:      errPipe,
 		Env:          config.Env,
 		TaskDir:      config.TaskDir().Dir,
+		WorkDir:      opts.WorkDir,
 		User:         config.User,
 		Cgroup:       cgroup,
 		Net:          netns(config),
@@ -326,6 +327,7 @@ func (p *Plugin) RecoverTask(handle *drivers.TaskHandle) error {
 		User:    handle.Config.User,
 		Cgroup:  cgroup,
 	}
+	// WorkDir is not needed for recovery (task is already running)
 
 	taskLogger := p.logger.With(
 		"alloc_id", taskState.TaskConfig.AllocID,
@@ -526,6 +528,11 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		return nil, fmt.Errorf("failed to decode driver task config: %w", err)
 	}
 
+	// work_dir must be an absolute path when set
+	if taskConfig.WorkDir != "" && !filepath.IsAbs(taskConfig.WorkDir) {
+		return nil, fmt.Errorf("work_dir must be an absolute path: %q", taskConfig.WorkDir)
+	}
+
 	// combine paths to unveil from plugin config, task config (if enabled),
 	// and some task/alloc directory default paths
 	unveil := slices.Clone(p.config.UnveilPaths)
@@ -539,6 +546,13 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_SECRETS_DIR"])
 		parent := filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"])
 		unveil = append(unveil, "rwxc:"+filepath.Join(parent, "tmp"))
+	}
+
+	// if work_dir is set, it must be accessible under Landlock — the task
+	// cannot chdir into a veiled directory. Auto-unveil it with rwxc so the
+	// task can read, write, execute, and create files there.
+	if taskConfig.WorkDir != "" {
+		unveil = append(unveil, "rwxc:"+taskConfig.WorkDir)
 	}
 
 	if len(taskConfig.Unveil) > 0 {
@@ -556,5 +570,6 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 		UnveilPaths:    unveil,
 		UnveilDefaults: p.config.UnveilDefaults,
 		OOMScoreAdj:    taskConfig.OOMScoreAdj,
+		WorkDir:        taskConfig.WorkDir,
 	}, nil
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -553,15 +554,23 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	}
 
 	// if work_dir is set, it must be accessible under Landlock — the task
-	// cannot chdir into a veiled directory. Auto-unveil it with rwxc so the
-	// task can read, write, execute, and create files there.
-	// work_dir_by_task must be enabled in the plugin config to allow job
-	// authors to set an arbitrary working directory.
+	// cannot chdir into a veiled directory.
+	//
+	// work_dir that resolves inside the alloc directory is already unveiled by
+	// the defaults block above — no gate is needed and no extra unveil entry
+	// is required. work_dir outside the alloc directory expands the filesystem
+	// surface, so it uses the same unveil_by_task gate as task-specified
+	// unveil paths.
 	if taskConfig.WorkDir != "" {
-		if !p.config.WorkDirByTask {
-			return nil, fmt.Errorf("task set work_dir but driver config does not allow this")
+		// alloc root is the grandparent of NOMAD_TASK_DIR:
+		// NOMAD_TASK_DIR = <alloc>/<task>/local  →  alloc root = <alloc>
+		allocRoot := filepath.Dir(filepath.Dir(driverTaskConfig.Env["NOMAD_TASK_DIR"]))
+		if !withinDir(allocRoot, taskConfig.WorkDir) {
+			if !p.config.UnveilByTask {
+				return nil, fmt.Errorf("task set work_dir outside sandbox but driver config does not allow this")
+			}
+			unveil = append(unveil, "rwxc:"+taskConfig.WorkDir)
 		}
-		unveil = append(unveil, "rwxc:"+taskConfig.WorkDir)
 	}
 
 	if len(taskConfig.Unveil) > 0 {
@@ -583,3 +592,10 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	}, nil
 }
 
+// withinDir reports whether path is equal to dir or nested inside it.
+// It uses filepath.Rel so separator arithmetic is handled by the standard
+// library — a relative result starting with ".." means path is outside dir.
+func withinDir(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && !strings.HasPrefix(rel, "..")
+}

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -149,11 +149,12 @@ func TestFunctional_cases(t *testing.T) {
 		name string
 
 		// task config
-		user    string
-		command string
-		args    []string
-		unveil  []string
-		workDir string
+		user           string
+		command        string
+		args           []string
+		unveil         []string
+		workDir        string // absolute path, or empty for default ($NOMAD_TASK_DIR)
+		workDirAllocDir bool  // if true, work_dir is set to NOMAD_ALLOC_DIR at runtime
 
 		// plugin config
 		unveilDefaults bool
@@ -449,6 +450,16 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: true,
 			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
+		// work_dir overrides the default CWD
+		{
+			name:            "work_dir overrides cwd",
+			user:            "nomad-84000",
+			command:         "sh",
+			args:            []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
+			workDirAllocDir: true,
+			unveilDefaults:  true,
+			exp:             &drivers.ExitResult{ExitCode: 0},
+		},
 	}
 
 	for _, tc := range cases {
@@ -457,13 +468,6 @@ func TestFunctional_cases(t *testing.T) {
 				UnveilDefaults: tc.unveilDefaults,
 				UnveilByTask:   tc.unveilByTask,
 				UnveilPaths:    tc.unveilPaths,
-			}
-
-			taskConfig := &TaskConfig{
-				Command: tc.command,
-				Args:    tc.args,
-				Unveil:  tc.unveil,
-				WorkDir: tc.workDir,
 			}
 
 			allocID := uuid.Generate()
@@ -477,12 +481,26 @@ func TestFunctional_cases(t *testing.T) {
 				Resources: basicResources(allocID, taskName),
 			}
 
-			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
-
 			harness := newTestHarness(t, pluginConfig)
 			harness.MakeTaskCgroup(task.AllocID, task.Name)
 			cleanup := harness.MkAllocDir(task, true)
 			defer cleanup()
+
+			// workDirAllocDir cases cannot set an absolute path at definition time
+			// because task.Env is only populated after MkAllocDir; resolve it here
+			workDir := tc.workDir
+			if tc.workDirAllocDir {
+				workDir = task.Env["NOMAD_ALLOC_DIR"]
+			}
+
+			taskConfig := &TaskConfig{
+				Command: tc.command,
+				Args:    tc.args,
+				Unveil:  tc.unveil,
+				WorkDir: workDir,
+			}
+
+			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 
 			// Start the task
 			_, _, err := harness.StartTask(task)
@@ -507,58 +525,6 @@ func TestFunctional_cases(t *testing.T) {
 			// Assert logs contain expected outputs
 			checkLogs(t, task, tc.stdoutRe, tc.stderrRe)
 		})
-	}
-}
-
-// TestFunctional_WorkDir verifies that setting work_dir in task config changes
-// the working directory of the task process to the specified path.
-func TestFunctional_WorkDir(t *testing.T) {
-	ctests.RequireRoot(t)
-
-	ci.Parallel(t)
-
-	pluginConfig := &Config{
-		UnveilDefaults: true,
-	}
-
-	allocID := uuid.Generate()
-	taskName := "work_dir_test_" + uuid.Short()
-
-	task := &drivers.TaskConfig{
-		User:      "nomad-84000",
-		ID:        uuid.Generate(),
-		Name:      taskName,
-		AllocID:   allocID,
-		Resources: basicResources(allocID, taskName),
-	}
-
-	harness := newTestHarness(t, pluginConfig)
-	harness.MakeTaskCgroup(task.AllocID, task.Name)
-	cleanup := harness.MkAllocDir(task, true)
-	defer cleanup()
-
-	// use the alloc dir as a custom working directory (always unveiled by default)
-	allocDir := task.Env["NOMAD_ALLOC_DIR"]
-
-	taskConfig := &TaskConfig{
-		Command: "sh",
-		Args:    []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
-		WorkDir: allocDir,
-	}
-	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
-
-	_, _, err := harness.StartTask(task)
-	must.NoError(t, err)
-	defer func() { _ = harness.DestroyTask(task.ID, true) }()
-
-	waitCh, err := harness.WaitTask(context.Background(), task.ID)
-	must.NoError(t, err)
-
-	select {
-	case result := <-waitCh:
-		must.Eq(t, &drivers.ExitResult{ExitCode: 0}, result, debugExitResult(result))
-	case <-time.After(10 * time.Second):
-		t.Fatalf("timeout")
 	}
 }
 

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -153,6 +153,7 @@ func TestFunctional_cases(t *testing.T) {
 		command string
 		args    []string
 		unveil  []string
+		workDir string
 
 		// plugin config
 		unveilDefaults bool
@@ -439,6 +440,15 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`\w+/tmp/tmp\.\w+`),
 		},
+		// cwd is the task directory (not in a veiled parent path)
+		{
+			name:           "cwd is task dir",
+			user:           "nomad-83000",
+			command:        "sh",
+			args:           []string{"-c", `test "$(pwd)" = "$NOMAD_TASK_DIR"`},
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
+		},
 	}
 
 	for _, tc := range cases {
@@ -453,6 +463,7 @@ func TestFunctional_cases(t *testing.T) {
 				Command: tc.command,
 				Args:    tc.args,
 				Unveil:  tc.unveil,
+				WorkDir: tc.workDir,
 			}
 
 			allocID := uuid.Generate()
@@ -497,6 +508,95 @@ func TestFunctional_cases(t *testing.T) {
 			checkLogs(t, task, tc.stdoutRe, tc.stderrRe)
 		})
 	}
+}
+
+// TestFunctional_WorkDir verifies that setting work_dir in task config changes
+// the working directory of the task process to the specified path.
+func TestFunctional_WorkDir(t *testing.T) {
+	ctests.RequireRoot(t)
+
+	ci.Parallel(t)
+
+	pluginConfig := &Config{
+		UnveilDefaults: true,
+	}
+
+	allocID := uuid.Generate()
+	taskName := "work_dir_test_" + uuid.Short()
+
+	task := &drivers.TaskConfig{
+		User:      "nomad-84000",
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		AllocID:   allocID,
+		Resources: basicResources(allocID, taskName),
+	}
+
+	harness := newTestHarness(t, pluginConfig)
+	harness.MakeTaskCgroup(task.AllocID, task.Name)
+	cleanup := harness.MkAllocDir(task, true)
+	defer cleanup()
+
+	// use the alloc dir as a custom working directory (always unveiled by default)
+	allocDir := task.Env["NOMAD_ALLOC_DIR"]
+
+	taskConfig := &TaskConfig{
+		Command: "sh",
+		Args:    []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
+		WorkDir: allocDir,
+	}
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
+
+	_, _, err := harness.StartTask(task)
+	must.NoError(t, err)
+	defer func() { _ = harness.DestroyTask(task.ID, true) }()
+
+	waitCh, err := harness.WaitTask(context.Background(), task.ID)
+	must.NoError(t, err)
+
+	select {
+	case result := <-waitCh:
+		must.Eq(t, &drivers.ExitResult{ExitCode: 0}, result, debugExitResult(result))
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+// TestFunctional_WorkDir_RelativePathRejected verifies that a relative work_dir
+// is rejected at task start time with a clear error.
+func TestFunctional_WorkDir_RelativePathRejected(t *testing.T) {
+	ctests.RequireRoot(t)
+
+	ci.Parallel(t)
+
+	pluginConfig := &Config{
+		UnveilDefaults: true,
+	}
+
+	allocID := uuid.Generate()
+	taskName := "work_dir_rel_test_" + uuid.Short()
+
+	task := &drivers.TaskConfig{
+		User:      "nomad-84000",
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		AllocID:   allocID,
+		Resources: basicResources(allocID, taskName),
+	}
+
+	taskConfig := &TaskConfig{
+		Command: "pwd",
+		WorkDir: "relative/path",
+	}
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
+
+	harness := newTestHarness(t, pluginConfig)
+	harness.MakeTaskCgroup(task.AllocID, task.Name)
+	cleanup := harness.MkAllocDir(task, true)
+	defer cleanup()
+
+	_, _, err := harness.StartTask(task)
+	must.ErrorContains(t, err, "work_dir must be an absolute path")
 }
 
 func checkLogs(t *testing.T, task *drivers.TaskConfig, outRe, errRe *regexp.Regexp) {

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -158,7 +158,6 @@ func TestFunctional_cases(t *testing.T) {
 		// plugin config
 		unveilDefaults bool
 		unveilByTask   bool
-		workDirByTask  bool
 		unveilPaths    []string
 
 		// expectations
@@ -450,38 +449,38 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: true,
 			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
-		// work_dir overrides the default CWD using a relative path;
-		// "alloc" resolves to parent(NOMAD_TASK_DIR)/alloc == NOMAD_ALLOC_DIR
+		// work_dir inside sandbox — works without unveil_by_task because the
+		// alloc dir is already unveiled by defaults
 		{
-			name:           "work_dir overrides cwd",
+			name:           "work_dir overrides cwd to alloc dir",
 			user:           "nomad-84000",
 			command:        "sh",
 			args:           []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
-			workDir:        "alloc",
-			workDirByTask:  true,
+			workDir:        "alloc", // resolves to <alloc>/alloc == NOMAD_ALLOC_DIR
 			unveilDefaults: true,
+			unveilByTask:   false, // no gate needed — inside sandbox
 			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
-		// work_dir set but work_dir_by_task not enabled — must be rejected
-		{
-			name:           "work_dir rejected when work_dir_by_task false",
-			user:           "nomad-85000",
-			command:        "pwd",
-			workDir:        "local",
-			workDirByTask:  false,
-			unveilDefaults: true,
-			exp:            nil, // StartTask itself returns an error; no exit result
-		},
-		// relative work_dir is resolved against parent of NOMAD_TASK_DIR
+		// work_dir inside sandbox — relative path to task dir, no gate needed
 		{
 			name:           "work_dir relative path resolved",
 			user:           "nomad-86000",
 			command:        "sh",
 			args:           []string{"-c", `test "$(pwd)" = "$NOMAD_TASK_DIR"`},
-			workDir:        "local", // resolves to parent(NOMAD_TASK_DIR)/local == NOMAD_TASK_DIR
-			workDirByTask:  true,
+			workDir:        "local", // resolves to <alloc>/<task>/local == NOMAD_TASK_DIR
 			unveilDefaults: true,
+			unveilByTask:   false, // no gate needed — inside sandbox
 			exp:            &drivers.ExitResult{ExitCode: 0},
+		},
+		// work_dir outside sandbox without unveil_by_task — must be rejected
+		{
+			name:           "work_dir outside sandbox rejected without unveil_by_task",
+			user:           "nomad-85000",
+			command:        "pwd",
+			workDir:        "/tmp", // outside alloc dir — needs gate
+			unveilByTask:   false,
+			unveilDefaults: true,
+			exp:            nil, // StartTask itself returns an error; no exit result
 		},
 	}
 
@@ -490,7 +489,6 @@ func TestFunctional_cases(t *testing.T) {
 			pluginConfig := &Config{
 				UnveilDefaults: tc.unveilDefaults,
 				UnveilByTask:   tc.unveilByTask,
-				WorkDirByTask:  tc.workDirByTask,
 				UnveilPaths:    tc.unveilPaths,
 			}
 

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -149,16 +149,16 @@ func TestFunctional_cases(t *testing.T) {
 		name string
 
 		// task config
-		user           string
-		command        string
-		args           []string
-		unveil         []string
-		workDir        string // absolute path, or empty for default ($NOMAD_TASK_DIR)
-		workDirAllocDir bool  // if true, work_dir is set to NOMAD_ALLOC_DIR at runtime
+		user    string
+		command string
+		args    []string
+		unveil  []string
+		workDir string // relative or absolute path; empty defaults to NOMAD_TASK_DIR
 
 		// plugin config
 		unveilDefaults bool
 		unveilByTask   bool
+		workDirByTask  bool
 		unveilPaths    []string
 
 		// expectations
@@ -450,15 +450,38 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: true,
 			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
-		// work_dir overrides the default CWD
+		// work_dir overrides the default CWD using a relative path;
+		// "alloc" resolves to parent(NOMAD_TASK_DIR)/alloc == NOMAD_ALLOC_DIR
 		{
-			name:            "work_dir overrides cwd",
-			user:            "nomad-84000",
-			command:         "sh",
-			args:            []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
-			workDirAllocDir: true,
-			unveilDefaults:  true,
-			exp:             &drivers.ExitResult{ExitCode: 0},
+			name:           "work_dir overrides cwd",
+			user:           "nomad-84000",
+			command:        "sh",
+			args:           []string{"-c", `test "$(pwd)" = "$NOMAD_ALLOC_DIR"`},
+			workDir:        "alloc",
+			workDirByTask:  true,
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
+		},
+		// work_dir set but work_dir_by_task not enabled — must be rejected
+		{
+			name:           "work_dir rejected when work_dir_by_task false",
+			user:           "nomad-85000",
+			command:        "pwd",
+			workDir:        "local",
+			workDirByTask:  false,
+			unveilDefaults: true,
+			exp:            nil, // StartTask itself returns an error; no exit result
+		},
+		// relative work_dir is resolved against parent of NOMAD_TASK_DIR
+		{
+			name:           "work_dir relative path resolved",
+			user:           "nomad-86000",
+			command:        "sh",
+			args:           []string{"-c", `test "$(pwd)" = "$NOMAD_TASK_DIR"`},
+			workDir:        "local", // resolves to parent(NOMAD_TASK_DIR)/local == NOMAD_TASK_DIR
+			workDirByTask:  true,
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
 	}
 
@@ -467,6 +490,7 @@ func TestFunctional_cases(t *testing.T) {
 			pluginConfig := &Config{
 				UnveilDefaults: tc.unveilDefaults,
 				UnveilByTask:   tc.unveilByTask,
+				WorkDirByTask:  tc.workDirByTask,
 				UnveilPaths:    tc.unveilPaths,
 			}
 
@@ -486,24 +510,23 @@ func TestFunctional_cases(t *testing.T) {
 			cleanup := harness.MkAllocDir(task, true)
 			defer cleanup()
 
-			// workDirAllocDir cases cannot set an absolute path at definition time
-			// because task.Env is only populated after MkAllocDir; resolve it here
-			workDir := tc.workDir
-			if tc.workDirAllocDir {
-				workDir = task.Env["NOMAD_ALLOC_DIR"]
-			}
-
 			taskConfig := &TaskConfig{
 				Command: tc.command,
 				Args:    tc.args,
 				Unveil:  tc.unveil,
-				WorkDir: workDir,
+				WorkDir: tc.workDir,
 			}
 
 			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 
 			// Start the task
 			_, _, err := harness.StartTask(task)
+
+			// cases with exp==nil expect StartTask itself to return an error
+			if tc.exp == nil {
+				must.Error(t, err)
+				return
+			}
 			must.NoError(t, err)
 
 			defer func() { _ = harness.DestroyTask(task.ID, true) }()
@@ -526,43 +549,6 @@ func TestFunctional_cases(t *testing.T) {
 			checkLogs(t, task, tc.stdoutRe, tc.stderrRe)
 		})
 	}
-}
-
-// TestFunctional_WorkDir_RelativePathRejected verifies that a relative work_dir
-// is rejected at task start time with a clear error.
-func TestFunctional_WorkDir_RelativePathRejected(t *testing.T) {
-	ctests.RequireRoot(t)
-
-	ci.Parallel(t)
-
-	pluginConfig := &Config{
-		UnveilDefaults: true,
-	}
-
-	allocID := uuid.Generate()
-	taskName := "work_dir_rel_test_" + uuid.Short()
-
-	task := &drivers.TaskConfig{
-		User:      "nomad-84000",
-		ID:        uuid.Generate(),
-		Name:      taskName,
-		AllocID:   allocID,
-		Resources: basicResources(allocID, taskName),
-	}
-
-	taskConfig := &TaskConfig{
-		Command: "pwd",
-		WorkDir: "relative/path",
-	}
-	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
-
-	harness := newTestHarness(t, pluginConfig)
-	harness.MakeTaskCgroup(task.AllocID, task.Name)
-	cleanup := harness.MkAllocDir(task, true)
-	defer cleanup()
-
-	_, _, err := harness.StartTask(task)
-	must.ErrorContains(t, err, "work_dir must be an absolute path")
 }
 
 func checkLogs(t *testing.T, task *drivers.TaskConfig, outRe, errRe *regexp.Regexp) {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/83

**Summary**

A task started by exec2 ran with its working directory set to the Nomad client's private internal alloc directory (`data/alloc/<id>/<task>`) rather than the unveiled bind-mount path (`$NOMAD_TASK_DIR`). Under Linux Landlock LSM, that private path is not in the unveil list, so any operation that reconstructs the CWD as a path string — `pwd`, `cd $(pwd)`, relative file writes — either produced the wrong path or failed with Permission denied on hardened systems.

The fix explicitly sets `cmd.Dir` on the inner task process to `$NOMAD_TASK_DIR`, matching the behaviour of Nomad's built-in raw_exec and exec drivers. An optional `work_dir` task config field is also added for consistency with those drivers.

**Root Cause**

**Two-process chain**
The exec2 driver runs tasks through a two-process chain. Both processes need their working directory set explicitly:

```
Nomad agent (root)
  └── nsenter → unshare → exec2-shim          ← outer process (shim.go / prepare())
                                   └── task binary   ← inner process (z_shim_cmd.go)
```

**What was missing**

`prepare()` in shim.go set` cmd.Dir = e.env.TaskDir `(the private path) for the outer shim process. `z_shim_cmd.go` built the inner task exec.Command with no `cmd.Dir `at all — so the task inherited whatever CWD the shim had after Landlock lockdown.

After lockdown() applied Landlock restrictions, the kernel could no longer traverse ancestor directories of the inherited CWD to reconstruct the path string, because those ancestors (data/alloc/…) were not in the unveil list. Only the bind-mount paths (`$NOMAD_TASK_DIR, $NOMAD_ALLOC_DIR…`) were unveiled.

**Additional Improvement — work_dir task config field**

As per discussion in the issue, exec2 should be consistent with Nomad's built-in drivers. All of `raw_exec`, `exec`, and `java` expose a work_dir task config field that overrides the default CWD. This PR adds the same.

```
task "example" {
  driver = "exec2"
  config {
    command  = "/usr/bin/my-service"
    work_dir = "/opt/my-service/data"   # optional; must be absolute
  }
}
```


Behaviour | Default (no work_dir) | With work_dir
-- | -- | --
Task CWD | $NOMAD_TASK_DIR | The specified absolute path
NOMAD_WORK_DIR env var | Set to $NOMAD_TASK_DIR | Set to the specified path
Landlock unveil | No extra unveil needed | Path auto-unveiled with rwxc regardless of unveil_defaults
Relative path | n/a | Rejected at task start: "work_dir must be an absolute path"

<br class="Apple-interchange-newline">

**Testing**
<details>

1) 
```
job "e2job" {
  reschedule {
    attempts  = 0
    unlimited = false
  }
  type = "service"
  group "e2g" {
    count = 1
    task "e2t" {
      restart {
        attempts = 0
      }
      driver = "exec2"
      config {
        command = "${NOMAD_TASK_DIR}/run.sh"
      }
      template {
        destination = "local/run.sh"
        perms       = "0755"
        data        = <<EOD
#!/bin/bash
set -x
exec 2>&1
whoami
env | grep NOMAD_TASK_DIR
env | grep NOMAD_ALLOC_DIR

# This is what pwd reports — should be $NOMAD_TASK_DIR but is the veiled private path
pwd

cd local
pwd

# This is the smoking-gun: cd $(pwd) should be a no-op but fails under Landlock
# because $(pwd) expands to the *private* unveil path not the alloc_mounts path
cd $(pwd)

# Traverse via relative .. — this still works (relative open from an already-open fd)
cd ../secrets
pwd

sleep 1d
EOD
      }

      resources {
        cpu    = 100
        memory = 64
      }
    }
  }
}
```

Result Before:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs f0d109d5
+ whoami
whoami: failed to get username: No such id: 84269
+ env
+ grep NOMAD_TASK_DIR
NOMAD_TASK_DIR=/tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f-e2t/local
+ env
+ grep NOMAD_ALLOC_DIR
NOMAD_ALLOC_DIR=/tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f-e2t/alloc
+ pwd
/tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f/e2t
+ cd local
+ pwd
/tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f/e2t/local
++ pwd
+ cd /tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f/e2t/local
+ cd ../secrets
+ pwd
/tmp/NomadClient3733059173/f0d109d5-5b38-487d-4aa6-a917e5718f8f/e2t/secrets
+ sleep 1d
```

Result After Fix:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs f5615d42
+ whoami
whoami: failed to get username: No such id: 88392
+ env
+ grep NOMAD_TASK_DIR
NOMAD_TASK_DIR=/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/local
+ env
+ grep NOMAD_ALLOC_DIR
NOMAD_ALLOC_DIR=/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/alloc
+ pwd
/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/local
+ cd local
/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/local/run.sh: line 11: cd: local: No such file or directory
+ pwd
/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/local
++ pwd
+ cd /tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/local
+ cd ../secrets
+ pwd
/tmp/NomadClient1676072496/f5615d42-1661-6e69-2782-229fd587e676-e2t/secrets
+ sleep 1d
```

2)  relative file write succeeds
```
job "relwrite" {
  type = "batch"

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "task" {
      driver = "exec2"

      config {
        command = "sh"
        args = [
          "-c",
          "echo hello > output.txt && cat output.txt"
        ]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result Berfore:
`/usr/bin/sh: 1: cannot create output.txt: Permission denied`

Result After Fix:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs 14f62cff
hello
```

3) work_dir overrides the default CWD
```
job "work-dir" {
  type = "batch"

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "task" {
      driver = "exec2"

      config {
        command = "sh"
        args = [
          "-c",
          "test \"$(pwd)\" = \"$NOMAD_ALLOC_DIR\" && echo WORKDIR_OK"
        ]
        work_dir = "${NOMAD_ALLOC_DIR}"
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs e2016d35
WORKDIR_OK
```

4) work_dir rejects a relative path
```
job "work-dir-bad" {
  type = "batch"

  group "group" {
    task "task" {
      driver = "exec2"

      config {
        command = "pwd"
        work_dir = "relative/path"
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc status 86562092
ID                   = 86562092-e86d-3418-5826-5e6fbfca72f5
Eval ID              = 81de2ed5
Name                 = work-dir-bad.group[0]
Node ID              = 616ee344
Node Name            = podman-dev
Job ID               = work-dir-bad
Job Version          = 0
Client Status        = failed
Client Description   = Failed tasks
Desired Status       = stop
Desired Description  = alloc was rescheduled because it failed
Created              = 7s ago
Modified             = 3s ago
Replacement Alloc ID = d831cd60

Task "task" is "dead"
Task Resources:
CPU      Memory  Disk     Addresses
100 MHz  32 MiB  300 MiB  

Task Events:
Started At     = N/A
Finished At    = 2026-08-04T06:52:44Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type            Description
2026-08-04T12:22:44+05:30  Not Restarting  Error was unrecoverable
2026-08-04T12:22:44+05:30  Driver Failure  rpc error: code = Unknown desc = work_dir must be an absolute path: "relative/path"
2026-08-04T12:22:44+05:30  Task Setup      Building Task Directory
2026-08-04T12:22:44+05:30  Received        Task received by client
```







</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

