### PR TITLE
fix: GOMAXPROCS auto-detection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+* Fixed `GOMAXPROCS` to prevent Go workloads from being over-threaded against the host CPU capacity. [[GH-98](https://github.com/hashicorp/nomad-driver-exec2/pull/98)]
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]
 
 ## 0.1.2 (May 12, 2026)

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -52,6 +52,11 @@ func lockdown(defaults bool, elements []string) error {
 			landlock.Dir("/usr/bin", "rx"),
 			landlock.Dir("/usr/local/bin", "rx"),
 		)
+		// expose /proc read-only so runtimes (Go 1.25+, JVM, dotnet) can read
+		// /proc/self/cgroup and /proc/self/mountinfo to discover their cgroup
+		// CPU and memory limits. unshare --mount-proc creates 
+		// an isolated /proc scoped to the task's PID namespace.
+		paths = append(paths, landlock.Dir("/proc", "r"))
 	}
 
 	return landlock.New(paths...).Lock(landlock.Mandatory)

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -228,6 +229,22 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	// get our assigned cpuset cores
 	cpuset := config.Resources.LinuxResources.CpusetCpus
 	p.logger.Trace("resources", "memory", memory, "memory_max", memoryMax, "compute", bandwidth, "cpuset", cpuset)
+
+	// compute and inject GOMAXPROCS so Go workloads see the correct parallelism
+	// limit rather than defaulting to the total host CPU count. The Go runtime
+	// cannot reliably auto-detect this inside an exec2 task because Landlock
+	// restricts access to /sys/fs/cgroup and /sys/devices/system/cpu by default.
+	//
+	// bandwidth is the cgroup cpu.max quota in microseconds per 100_000 µs period.
+	// Ceiling integer division by the period gives the whole-core equivalent:
+	//   cores=N tasks:   bandwidth = N × 100_000 → result = N (exact)
+	//   cpu=M MHz tasks: bandwidth = M×100_000/per_core_MHz → result = ceil(fraction)
+	//
+	// Only inject if the operator has not already set it explicitly.
+	if _, alreadySet := config.Env["GOMAXPROCS"]; !alreadySet {
+		gomaxprocs := max(1, int((bandwidth+99_999)/100_000))
+		config.Env["GOMAXPROCS"] = strconv.Itoa(gomaxprocs)
+	}
 
 	// with cgroups v2 this is just the task cgroup
 	cgroup := config.Resources.LinuxResources.CpusetCgroupPath

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -231,9 +231,13 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	p.logger.Trace("resources", "memory", memory, "memory_max", memoryMax, "compute", bandwidth, "cpuset", cpuset)
 
 	// compute and inject GOMAXPROCS so Go workloads see the correct parallelism
-	// limit rather than defaulting to the total host CPU count. The Go runtime
-	// cannot reliably auto-detect this inside an exec2 task because Landlock
-	// restricts access to /sys/fs/cgroup and /sys/devices/system/cpu by default.
+	// limit rather than defaulting to the total host CPU count.
+	//
+	// Go 1.25+ can read cpu.max from the task's own cgroup scope (now always
+	// unveiled read-only via setOptions) and auto-detect correctly. However Go
+	// 1.24 and below never read cgroup at all — they fall back to
+	// sched_getaffinity() which returns all host cores for cpu=N MHz tasks.
+	// The env var injection covers all Go versions uniformly.
 	//
 	// bandwidth is the cgroup cpu.max quota in microseconds per 100_000 µs period.
 	// Ceiling integer division by the period gives the whole-core equivalent:
@@ -550,6 +554,8 @@ func (p *Plugin) setOptions(driverTaskConfig *drivers.TaskConfig) (*shim.Options
 	// if the plugin config.unveil_defaults value is set to true (very common)
 	// then automatically unveil the sandbox directories
 	if p.config.UnveilDefaults {
+		// Expose the task's cgroup read-only so runtimes can read resource limits.
+		unveil = append(unveil, "r:"+driverTaskConfig.Resources.LinuxResources.CpusetCgroupPath)
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_TASK_DIR"])
 		unveil = append(unveil, "rwxc:"+driverTaskConfig.Env["NOMAD_ALLOC_DIR"])
 		unveil = append(unveil, "rx:"+driverTaskConfig.Env["NOMAD_ALLOC_DIR"]+"/logs")

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -229,26 +228,6 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	// get our assigned cpuset cores
 	cpuset := config.Resources.LinuxResources.CpusetCpus
 	p.logger.Trace("resources", "memory", memory, "memory_max", memoryMax, "compute", bandwidth, "cpuset", cpuset)
-
-	// compute and inject GOMAXPROCS so Go workloads see the correct parallelism
-	// limit rather than defaulting to the total host CPU count.
-	//
-	// Go 1.25+ can read cpu.max from the task's own cgroup scope (now always
-	// unveiled read-only via setOptions) and auto-detect correctly. However Go
-	// 1.24 and below never read cgroup at all — they fall back to
-	// sched_getaffinity() which returns all host cores for cpu=N MHz tasks.
-	// The env var injection covers all Go versions uniformly.
-	//
-	// bandwidth is the cgroup cpu.max quota in microseconds per 100_000 µs period.
-	// Ceiling integer division by the period gives the whole-core equivalent:
-	//   cores=N tasks:   bandwidth = N × 100_000 → result = N (exact)
-	//   cpu=M MHz tasks: bandwidth = M×100_000/per_core_MHz → result = ceil(fraction)
-	//
-	// Only inject if the operator has not already set it explicitly.
-	if _, alreadySet := config.Env["GOMAXPROCS"]; !alreadySet {
-		gomaxprocs := max(1, int((bandwidth+99_999)/100_000))
-		config.Env["GOMAXPROCS"] = strconv.Itoa(gomaxprocs)
-	}
 
 	// with cgroups v2 this is just the task cgroup
 	cgroup := config.Resources.LinuxResources.CpusetCgroupPath

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -152,7 +152,6 @@ func TestFunctional_cases(t *testing.T) {
 		user    string
 		command string
 		args    []string
-		env     map[string]string
 		unveil  []string
 
 		// plugin config
@@ -440,28 +439,6 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`\w+/tmp/tmp\.\w+`),
 		},
-		// GOMAXPROCS is injected from CPU bandwidth allocation so Go workloads
-		// see the correct parallelism limit rather than the host CPU count.
-		{
-			name:           "GOMAXPROCS injected from bandwidth",
-			user:           "root",
-			command:        "printenv",
-			args:           []string{"GOMAXPROCS"},
-			unveilDefaults: true,
-			exp:            &drivers.ExitResult{ExitCode: 0},
-			stdoutRe:       regexp.MustCompile(`^1$`),
-		},
-		// Operator-supplied GOMAXPROCS must not be overwritten by the driver.
-		{
-			name:           "GOMAXPROCS operator override preserved",
-			user:           "root",
-			command:        "printenv",
-			args:           []string{"GOMAXPROCS"},
-			env:            map[string]string{"GOMAXPROCS": "8"},
-			unveilDefaults: true,
-			exp:            &drivers.ExitResult{ExitCode: 0},
-			stdoutRe:       regexp.MustCompile(`^8$`),
-		},
 	}
 
 	for _, tc := range cases {
@@ -479,20 +456,16 @@ func TestFunctional_cases(t *testing.T) {
 			}
 
 			allocID := uuid.Generate()
-			taskName := "test_cases_" + uuid.Short()
-
-			taskEnv := tc.env
-			if taskEnv == nil {
-				taskEnv = map[string]string{}
-			}
-			task := &drivers.TaskConfig{
-				User:      tc.user,
-				ID:        uuid.Generate(),
-				Name:      taskName,
-				AllocID:   allocID,
-				Env:       taskEnv,
-				Resources: basicResources(allocID, taskName),
-			}
+				taskName := "test_cases_" + uuid.Short()
+	
+				task := &drivers.TaskConfig{
+					User:      tc.user,
+					ID:        uuid.Generate(),
+					Name:      taskName,
+					AllocID:   allocID,
+					Env:       map[string]string{},
+					Resources: basicResources(allocID, taskName),
+				}
 
 			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -456,16 +456,15 @@ func TestFunctional_cases(t *testing.T) {
 			}
 
 			allocID := uuid.Generate()
-				taskName := "test_cases_" + uuid.Short()
-	
-				task := &drivers.TaskConfig{
-					User:      tc.user,
-					ID:        uuid.Generate(),
-					Name:      taskName,
-					AllocID:   allocID,
-					Env:       map[string]string{},
-					Resources: basicResources(allocID, taskName),
-				}
+			taskName := "test_cases_" + uuid.Short()
+
+			task := &drivers.TaskConfig{
+				User:      tc.user,
+				ID:        uuid.Generate(),
+				Name:      taskName,
+				AllocID:   allocID,
+				Resources: basicResources(allocID, taskName),
+			}
 
 			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -152,6 +152,7 @@ func TestFunctional_cases(t *testing.T) {
 		user    string
 		command string
 		args    []string
+		env     map[string]string
 		unveil  []string
 
 		// plugin config
@@ -439,6 +440,28 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`\w+/tmp/tmp\.\w+`),
 		},
+		// GOMAXPROCS is injected from CPU bandwidth allocation so Go workloads
+		// see the correct parallelism limit rather than the host CPU count.
+		{
+			name:           "GOMAXPROCS injected from bandwidth",
+			user:           "root",
+			command:        "printenv",
+			args:           []string{"GOMAXPROCS"},
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`^1$`),
+		},
+		// Operator-supplied GOMAXPROCS must not be overwritten by the driver.
+		{
+			name:           "GOMAXPROCS operator override preserved",
+			user:           "root",
+			command:        "printenv",
+			args:           []string{"GOMAXPROCS"},
+			env:            map[string]string{"GOMAXPROCS": "8"},
+			unveilDefaults: true,
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`^8$`),
+		},
 	}
 
 	for _, tc := range cases {
@@ -458,11 +481,16 @@ func TestFunctional_cases(t *testing.T) {
 			allocID := uuid.Generate()
 			taskName := "test_cases_" + uuid.Short()
 
+			taskEnv := tc.env
+			if taskEnv == nil {
+				taskEnv = map[string]string{}
+			}
 			task := &drivers.TaskConfig{
 				User:      tc.user,
 				ID:        uuid.Generate(),
 				Name:      taskName,
 				AllocID:   allocID,
+				Env:       taskEnv,
 				Resources: basicResources(allocID, taskName),
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/82

**_Summary_**

exec2 tasks saw `GOMAXPROCS` equal to the total host CPU count rather than their allocated CPU quota. This caused over-threading, excessive cgroup throttling, and degraded throughput for any Go binary scheduled with a fractional CPU share (e.g. cpu = 500 on a 32-core host). The driver now injects the correct value before the task process starts.

_**Root cause**_

The Go runtime auto-detects `GOMAXPROCS` at startup by reading two kernel interfaces. Both are silently blocked by Landlock inside an exec2 task. The Landlock allow-list even with `unveil_defaults = true`  does not include `/sys/fs/cgroup` or `/sys/devices/system/cpu`. So Go silently falls through to the host core count every time.
 
**_Fix_**
The fix injects `GOMAXPROCS` directly into the task environment in `StartTask()`, derived from the same bandwidth value already computed for writing to cpu.max. The formula uses integer ceiling division, so fractional shares round up to the next whole thread and reserved-core allocations (cores = N) produce an exact result because the per-core MHz cancels out. 

The injection is skipped if the operator has already set `GOMAXPROCS` explicitly in the job's env block. Because the value arrives as an environment variable, the Go runtime reads it via os.Getenv during runtime.init with no file I/O, and the kernel-enforced cgroup limit and the Go thread pool size are now always derived from the same source.

**_Why integer ceiling, not float64?_**
bandwidth is uint64. Converting to `float64` loses precision above 2^53. Integer ceiling division (n + d - 1) / d is exact for all representable values.

_**Data flow — how the value reaches the process**_

<img width="794" height="115" alt="Screenshot 2026-08-07 at 12 48 38 PM" src="https://github.com/user-attachments/assets/905709f3-04c1-45ca-b3d0-ba701f850878" />


_**Job spec examples**_

**Scenario A — fractional share (cpu = N MHz)**
```
resources {
  cpu    = 500    # 500 MHz on a 3 GHz host → bandwidth=16666 → GOMAXPROCS=1
  memory = 256
}
```
**Scenario B — whole core reservation (cores = N)**
```
resources {
  cores  = 2     # 2 reserved cores → bandwidth=200_000 → GOMAXPROCS=2 (exact)
  memory = 512
}
```
**Scenario C — verify inside the task**
```
config {
  command = "printenv"
  args    = ["GOMAXPROCS"]
}
```

**_Testing_**
<details>

1) 
```
job "gomaxprocs-test" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "g" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "check" {
      driver = "exec2"

      config {
        command = "gomaxprocs-check"
      }

      resources {
        cpu    = 500
        memory = 64
      }
    }
  }
}
```

Result before:
```
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad job run /tmp/gomaxprocs-job.hcl
==> 2026-08-06T14:14:26+05:30: Monitoring evaluation "0ef9ff6c"
    2026-08-06T14:14:26+05:30: Evaluation triggered by job "gomaxprocs-test"
    2026-08-06T14:14:27+05:30: Allocation "4233757b" created: node "2dd2ca81", group "g"
    2026-08-06T14:14:27+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-06T14:14:27+05:30: Evaluation "0ef9ff6c" finished with status "complete"
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ sleep 5 && nomad logs -job gomaxprocs-test check
GOMAXPROCS=14 NumCPU=14
```

Result After:
```
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad job run /tmp/gomaxprocs-job.hcl
==> 2026-08-06T14:18:05+05:30: Monitoring evaluation "f487422e"
    2026-08-06T14:18:05+05:30: Evaluation triggered by job "gomaxprocs-test"
    2026-08-06T14:18:06+05:30: Allocation "b6dce476" created: node "876a183c", group "g"
    2026-08-06T14:18:06+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-06T14:18:06+05:30: Evaluation "f487422e" finished with status "complete"
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ sleep 5 && nomad logs -job gomaxprocs-test check
GOMAXPROCS=1 NumCPU=14
```

2) 
```
job "gomaxprocs-cores" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "g" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "check" {
      driver = "exec2"

      config {
        command = "gomaxprocs-check"
      }

      resources {
        cores  = 1
        memory = 64
      }
    }
  }
}
EOF
```

Before Result:
```
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad job run /tmp/gomaxprocs-cores-job.hcl
==> 2026-08-07T13:25:11+05:30: Monitoring evaluation "c0ad6310"
    2026-08-07T13:25:11+05:30: Evaluation triggered by job "gomaxprocs-cores"
    2026-08-07T13:25:12+05:30: Allocation "efa53783" created: node "9a97a483", group "g"
    2026-08-07T13:25:12+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-07T13:25:12+05:30: Evaluation "c0ad6310" finished with status "complete"
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad logs -job gomaxprocs-cores check
GOMAXPROCS=1 NumCPU=1
```


After Result: 
```
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad job run /tmp/gomaxprocs-cores-job.hcl
==> 2026-08-07T13:35:29+05:30: Monitoring evaluation "0f1f72f9"
    2026-08-07T13:35:29+05:30: Evaluation triggered by job "gomaxprocs-cores"
    2026-08-07T13:35:29+05:30: Allocation "5f0ccb66" created: node "0018293f", group "g"
    2026-08-07T13:35:30+05:30: Allocation "5f0ccb66" status changed: "pending" -> "running" (Tasks are running)
    2026-08-07T13:35:30+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-07T13:35:30+05:30: Evaluation "0f1f72f9" finished with status "complete"
riteshharihar@podman-dev:/tmp/gomaxprocs-test$ nomad logs -job gomaxprocs-cores check
GOMAXPROCS=1 NumCPU=1
```


</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

