### PR TITLE
fix: mount namespace propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+* Fixed mount propagation so host mounts remain visible while task-internal mounts stay isolated from the host. [[GH-99](https://github.com/hashicorp/nomad-driver-exec2/pull/99)]
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]
 
 ## 0.1.2 (May 12, 2026)

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -364,12 +364,14 @@ func (e *exe) parameters(uid, gid int) []string {
 		)
 	}
 
-	// setup unshare for ipc, pid namespaces
+	// setup unshare for ipc, pid namespaces, and mount propagation
 	result = append(result,
 		"unshare",
 		"--ipc",
 		"--pid",
 		"--mount-proc",
+		"--propagation",
+		"slave",
 		"--fork",
 		"--kill-child=SIGKILL",
 		fmt.Sprintf("--setuid=%d", uid),

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -430,6 +430,19 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`root\s+1.+ps aux`), // out ps is pid 1
 		},
+		// mount namespace has slave propagation — host mounts propagate into
+		// the task not vice versa.
+		// The kernel records slave propagation as "master:N" in mountinfo.
+		{
+			name:           "mount propagation slave",
+			user:           "root",
+			command:        "awk",
+			args:           []string{"NR==1", "/proc/self/mountinfo"},
+			unveilDefaults: true,
+			unveilPaths:    []string{"r:/proc"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`master:\d+`),
+		},
 		// able to use TMPDIR
 		{
 			name:           "use TMPDIR",


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/74

**_Summary_**

exec2 tasks could not see `autofs`-mounted filesystems (or any other host mount created after the task started) because `unshare --mount-proc` implicitly created a mount namespace with `MS_PRIVATE` propagation, severing it from the host's mount tree. Adding `--propagation slave` restores propagation in one direction — host mounts flow into the task, task mounts do not leak to the host.

**_Root Cause_**

exec2 creates its task process tree using unshare. The `--mount-proc` flag is required to give the new PID namespace a private `/proc`, but this forces unshare to create a new mount namespace, and without an `explicit --propagation` flag that namespace defaults to `MS_PRIVATE` for every mount point.

`MS_PRIVATE` does not prevent mounts that existed before the namespace was created from being visible (they are snapshotted in). It prevents mounts created on the host after the namespace exists from propagating in. This is exactly how autofs works, it creates mounts on demand, after tasks are already running.

The kernel records propagation type in /proc/self/mountinfo.

State | Root mount entry in /proc/self/mountinfo | Meaning
-- | -- | --
Before fix | ... / rw,noatime - btrfs ... | ✗ No peer group — MS_PRIVATE
After fix | ... / rw,noatime **master:35** - btrfs ... | ✓ Slave of peer group 35 — receives host propagation

<br class="Apple-interchange-newline">

**_Options explored_**

Option | Issue
-- | --
--propagation slave (chosen) |  correct on every host, no new privileges, no config surface
--propagation unchanged | Works on some hosts, silently fails on others (it inherits whatever propagation the parent namespace has, which varies by host and container environment)
mount --make-slave in shim | Needs elevated privilege just to work around something unshare already handles natively
Config option | Exposes the broken state as a valid choice; no real use case for any value except slave

**_Practical example_**

- Before fix: task fails with No such file or directory — mount not even visible.
- After fix, without unveil: task fails with Permission denied — mount visible, Landlock blocks it.
- After fix, with unveil:

```
config {
  command = "/bin/cat"
  args    = ["/nfs/data/file.txt"]
  unveil  = ["r:/nfs/data"]
}
```
Task succeeds  mount visible and Landlock allows access.

This PR fixes the prerequisite that was completely broken. The Landlock layer was already working correctly and just needs the operator to unveil the `autofs` paths as they would for any other filesystem path. The two layers are independent and both must be satisfied.

**_Testing_**
<details>


```
 job "mount-test" {
  type = "batch"
  group "group" {
    task "check" {
      driver = "exec2"
      config {
        command = "/usr/bin/awk"
        args    = ["NR==1", "/proc/self/mountinfo"]
        unveil  = ["r:/proc"]
      }
    }
  }
}
```


**Before:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad job run /tmp/mount-test.hcl
==> 2026-08-11T15:13:55+05:30: Monitoring evaluation "65364008"
    2026-08-11T15:13:55+05:30: Evaluation triggered by job "mount-test"
    2026-08-11T15:13:56+05:30: Allocation "ca908b94" created: node "e2feae5d", group "group"
    2026-08-11T15:13:56+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-11T15:13:56+05:30: Evaluation "65364008" finished with status "complete"

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs 
811 808 0:38 /scon/containers/01KS4F7XKHAVX614ZKDHGS499Q/rootfs / rw,noatime - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=333,subvol=/scon/containers/01KS4F7XKHAVX614ZKDHGS499Q
```

**After:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad job run /tmp/mount-test.hcl
==> 2026-08-11T15:17:40+05:30: Monitoring evaluation "4a280b01"
    2026-08-11T15:17:40+05:30: Evaluation triggered by job "mount-test"
    2026-08-11T15:17:40+05:30: Allocation "3d37353c" created: node "7a43f8f2", group "group"
    2026-08-11T15:17:41+05:30: Allocation "3d37353c" status changed: "pending" -> "running" (Tasks are running)
    2026-08-11T15:17:41+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-11T15:17:41+05:30: Evaluation "4a280b01" finished with status "complete"

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs 3d37353c
811 808 0:38 /scon/containers/01KS4F7XKHAVX614ZKDHGS499Q/rootfs / rw,noatime master:35 - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=333,subvol=/scon/containers/01KS4F7XKHAVX614ZKDHGS499Q
```





</details>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

