### PR TITLE
fix: permission denied error for /proc/self/mountinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* Fixed `permission denied` when a task reads files under `/proc` or `/sys` (e.g. `r:/proc/self/mountinfo`) via an explicit `unveil` entry. [[GH-100](https://github.com/hashicorp/nomad-driver-exec2/pull/100)]
 * Fixed mount propagation so host mounts remain visible while task-internal mounts stay isolated from the host. [[GH-99](https://github.com/hashicorp/nomad-driver-exec2/pull/99)]
 * Fixed `GOMAXPROCS` to prevent Go workloads from being over-threaded against the host CPU capacity. [[GH-98](https://github.com/hashicorp/nomad-driver-exec2/pull/98)]
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* Fixed `permission denied` when a task reads files under `/proc` or `/sys` (e.g. `r:/proc/self/mountinfo`) via an explicit `unveil` entry. [[GH-100](https://github.com/hashicorp/nomad-driver-exec2/pull/100)]
+* Fixed `permission denied` when a task reads files under `/proc` (e.g. `r:/proc/self/mountinfo`) via an explicit `unveil` entry. [[GH-100](https://github.com/hashicorp/nomad-driver-exec2/pull/100)]
 * Fixed mount propagation so host mounts remain visible while task-internal mounts stay isolated from the host. [[GH-99](https://github.com/hashicorp/nomad-driver-exec2/pull/99)]
 * Fixed `GOMAXPROCS` to prevent Go workloads from being over-threaded against the host CPU capacity. [[GH-98](https://github.com/hashicorp/nomad-driver-exec2/pull/98)]
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -11,6 +11,27 @@ import (
 	"github.com/shoenig/go-landlock"
 )
 
+// virtualFS lists filesystem roots that are virtual (kernel-generated).
+// Their inodes are namespace-scoped: os.Stat on a path like /proc/self/mountinfo
+// follows the /proc/self symlink to the shim's own PID inode, which does not
+// exist in the task's private namespace after unshare --mount-proc.
+// All paths under these roots must be treated as directories without stat(2).
+var virtualFS = []string{
+	"/proc",
+	"/sys",
+}
+
+// virtualFSRoot returns the virtual filesystem root that contains path,
+// or "" if path is not under any known virtual filesystem.
+func virtualFSRoot(path string) string {
+	for _, root := range virtualFS {
+		if path == root || strings.HasPrefix(path, root+"/") {
+			return root
+		}
+	}
+	return ""
+}
+
 // When the nomad binary is invoked as exec2-shim, the format is
 // nomad exec2-shim [path, [...]] -- [commands, [...]]
 // so basically we need to find the first instance of '--' and split on that
@@ -73,6 +94,15 @@ func convert(elements []string) ([]*landlock.Path, error) {
 
 		mode := path[0:idx]
 		filepath := path[idx+1:]
+
+		// Virtual filesystems (/proc, /sys) have namespace-scoped inodes.
+		// os.Stat would resolve /proc/self to the shim's PID inode, which
+		// does not exist in the task's private namespace after unshare --mount-proc.
+		// Skip stat entirely and register the path as a directory.
+		if virtualFSRoot(filepath) != "" {
+			paths = append(paths, landlock.Dir(filepath, mode))
+			continue
+		}
 
 		info, err := os.Stat(filepath)
 		if err != nil {

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -95,18 +95,22 @@ func convert(elements []string) ([]*landlock.Path, error) {
 		mode := path[0:idx]
 		filepath := path[idx+1:]
 
-		// Virtual filesystems (/proc, /sys) have namespace-scoped inodes.
-		// os.Stat would resolve /proc/self to the shim's PID inode, which
-		// does not exist in the task's private namespace after unshare --mount-proc.
-		// Skip stat entirely and register the path as a directory.
-		if virtualFSRoot(filepath) != "" {
-			paths = append(paths, landlock.Dir(filepath, mode))
-			continue
-		}
-
 		info, err := os.Stat(filepath)
+
+		// Virtual filesystems (/proc, /sys) have namespace-scoped inodes.
+		// /proc/self is a magic symlink that resolves to /proc/<shim-pid>;
+		// that inode does not survive unshare --mount-proc into the task's
+		// private namespace. We ignore stat errors for these paths and fall
+		// back to File, which is correct for any leaf entry under /proc or
+		// /sys (e.g. /proc/self/mountinfo). Paths that stat successfully
+		// (e.g. "/proc", "/sys", "/proc/cpuinfo") take the normal dir/file
+		// branch below.
 		if err != nil {
-			return nil, fmt.Errorf("failed to stat unveil path: %w", err)
+			if virtualFSRoot(filepath) == "" {
+				return nil, fmt.Errorf("failed to stat unveil path: %w", err)
+			}
+			paths = append(paths, landlock.File(filepath, mode))
+			continue
 		}
 
 		if info.IsDir() {

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -11,9 +11,9 @@ import (
 	"github.com/shoenig/go-landlock"
 )
 
-// isProcPath reports whether path is /proc or a descendant of /proc.
-func isProcPath(path string) bool {
-	return path == "/proc" || strings.HasPrefix(path, "/proc/")
+// isProcSelfPath reports whether path is a descendant of /proc/self or /proc/thread-self 
+func isProcSelfPath(path string) bool {
+	return strings.HasPrefix(path, "/proc/self/") || strings.HasPrefix(path, "/proc/thread-self/")
 }
 
 // When the nomad binary is invoked as exec2-shim, the format is
@@ -79,17 +79,20 @@ func convert(elements []string) ([]*landlock.Path, error) {
 		mode := path[0:idx]
 		filepath := path[idx+1:]
 
-		info, err := os.Stat(filepath)
+		// /proc/self/* and /proc/thread-self/* contain PID-scoped magic symlinks.
+		// go-landlock registers rules via O_PATH which pins the inode at the
+		// time of the open — resolving /proc/self to /proc/<shim-pid>. After
+		// unshare --mount-proc the task's private /proc has different inodes,
+		// making the pinned inode unreachable (EPERM). Promote these paths to
+		// Dir("/proc", mode) so the rule covers the whole /proc tree by its
+		// stable directory inode instead.
+		if isProcSelfPath(filepath) {
+			paths = append(paths, landlock.Dir("/proc", mode))
+			continue
+		}
 
-		// /proc/self/* paths fail to stat in the shim: /proc/self is a magic
-		// symlink resolved to /proc/<shim-pid>, which does not exist after
-		// unshare --mount-proc. Register by path string so the kernel
-		// re-resolves it inside the task's private mount namespace.
+		info, err := os.Stat(filepath)
 		if err != nil {
-			if isProcPath(filepath) {
-				paths = append(paths, landlock.File(filepath, mode))
-				continue
-			}
 			return nil, fmt.Errorf("failed to stat unveil path: %w", err)
 		}
 

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -11,25 +11,9 @@ import (
 	"github.com/shoenig/go-landlock"
 )
 
-// virtualFS lists filesystem roots that are virtual (kernel-generated).
-// Their inodes are namespace-scoped: os.Stat on a path like /proc/self/mountinfo
-// follows the /proc/self symlink to the shim's own PID inode, which does not
-// exist in the task's private namespace after unshare --mount-proc.
-// All paths under these roots must be treated as directories without stat(2).
-var virtualFS = []string{
-	"/proc",
-	"/sys",
-}
-
-// virtualFSRoot returns the virtual filesystem root that contains path,
-// or "" if path is not under any known virtual filesystem.
-func virtualFSRoot(path string) string {
-	for _, root := range virtualFS {
-		if path == root || strings.HasPrefix(path, root+"/") {
-			return root
-		}
-	}
-	return ""
+// isProcPath reports whether path is /proc or a descendant of /proc.
+func isProcPath(path string) bool {
+	return path == "/proc" || strings.HasPrefix(path, "/proc/")
 }
 
 // When the nomad binary is invoked as exec2-shim, the format is
@@ -97,20 +81,16 @@ func convert(elements []string) ([]*landlock.Path, error) {
 
 		info, err := os.Stat(filepath)
 
-		// Virtual filesystems (/proc, /sys) have namespace-scoped inodes.
-		// /proc/self is a magic symlink that resolves to /proc/<shim-pid>;
-		// that inode does not survive unshare --mount-proc into the task's
-		// private namespace. We ignore stat errors for these paths and fall
-		// back to File, which is correct for any leaf entry under /proc or
-		// /sys (e.g. /proc/self/mountinfo). Paths that stat successfully
-		// (e.g. "/proc", "/sys", "/proc/cpuinfo") take the normal dir/file
-		// branch below.
+		// /proc/self/* paths fail to stat in the shim: /proc/self is a magic
+		// symlink resolved to /proc/<shim-pid>, which does not exist after
+		// unshare --mount-proc. Register by path string so the kernel
+		// re-resolves it inside the task's private mount namespace.
 		if err != nil {
-			if virtualFSRoot(filepath) == "" {
-				return nil, fmt.Errorf("failed to stat unveil path: %w", err)
+			if isProcPath(filepath) {
+				paths = append(paths, landlock.File(filepath, mode))
+				continue
 			}
-			paths = append(paths, landlock.File(filepath, mode))
-			continue
+			return nil, fmt.Errorf("failed to stat unveil path: %w", err)
 		}
 
 		if info.IsDir() {

--- a/pkg/shim/sandbox_test.go
+++ b/pkg/shim/sandbox_test.go
@@ -6,7 +6,6 @@ package shim
 import (
 	"testing"
 
-	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )
 
@@ -38,59 +37,4 @@ func Test_split(t *testing.T) {
 			must.Eq(t, tc.cmds, cmds)
 		})
 	}
-}
-
-func Test_virtualFSRoot(t *testing.T) {
-	cases := []struct {
-		path   string
-		expect string
-	}{
-		{"/proc/self/mountinfo", "/proc"},
-		{"/proc/self/cgroup", "/proc"},
-		{"/proc/cpuinfo", "/proc"},
-		{"/proc", "/proc"},
-		{"/sys/fs/cgroup", "/sys"},
-		{"/sys", "/sys"},
-		{"/etc/passwd", ""},
-		{"/procfake", ""},
-		{"/usr/local/bin", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.path, func(t *testing.T) {
-			must.Eq(t, tc.expect, virtualFSRoot(tc.path))
-		})
-	}
-}
-
-func Test_convert_virtual(t *testing.T) {
-	// /proc/self/mountinfo must not be stat(2)'d — the shim's PID inode does
-	// not survive unshare --mount-proc. convert() must emit Dir without error.
-	paths, err := convert([]string{
-		"r:/proc/self/mountinfo",
-		"r:/proc/cpuinfo",
-		"r:/sys/fs/cgroup",
-	})
-	must.NoError(t, err)
-	must.Len(t, 3, paths)
-
-	// All three must be Dir rules (never File), regardless of what they look
-	// like on the host filesystem.
-	expected := []*landlock.Path{
-		landlock.Dir("/proc/self/mountinfo", "r"),
-		landlock.Dir("/proc/cpuinfo", "r"),
-		landlock.Dir("/sys/fs/cgroup", "r"),
-	}
-	must.Eq(t, expected, paths)
-}
-
-func Test_convert_missing(t *testing.T) {
-	// A non-virtual path that doesn't exist on disk must return an error.
-	_, err := convert([]string{"r:/nonexistent/path/xyz"})
-	must.Error(t, err)
-}
-
-func Test_convert_no_mode(t *testing.T) {
-	// A path with no mode prefix must return an error.
-	_, err := convert([]string{"/proc/cpuinfo"})
-	must.Error(t, err)
 }

--- a/pkg/shim/sandbox_test.go
+++ b/pkg/shim/sandbox_test.go
@@ -6,6 +6,7 @@ package shim
 import (
 	"testing"
 
+	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )
 
@@ -37,4 +38,59 @@ func Test_split(t *testing.T) {
 			must.Eq(t, tc.cmds, cmds)
 		})
 	}
+}
+
+func Test_virtualFSRoot(t *testing.T) {
+	cases := []struct {
+		path   string
+		expect string
+	}{
+		{"/proc/self/mountinfo", "/proc"},
+		{"/proc/self/cgroup", "/proc"},
+		{"/proc/cpuinfo", "/proc"},
+		{"/proc", "/proc"},
+		{"/sys/fs/cgroup", "/sys"},
+		{"/sys", "/sys"},
+		{"/etc/passwd", ""},
+		{"/procfake", ""},
+		{"/usr/local/bin", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			must.Eq(t, tc.expect, virtualFSRoot(tc.path))
+		})
+	}
+}
+
+func Test_convert_virtual(t *testing.T) {
+	// /proc/self/mountinfo must not be stat(2)'d — the shim's PID inode does
+	// not survive unshare --mount-proc. convert() must emit Dir without error.
+	paths, err := convert([]string{
+		"r:/proc/self/mountinfo",
+		"r:/proc/cpuinfo",
+		"r:/sys/fs/cgroup",
+	})
+	must.NoError(t, err)
+	must.Len(t, 3, paths)
+
+	// All three must be Dir rules (never File), regardless of what they look
+	// like on the host filesystem.
+	expected := []*landlock.Path{
+		landlock.Dir("/proc/self/mountinfo", "r"),
+		landlock.Dir("/proc/cpuinfo", "r"),
+		landlock.Dir("/sys/fs/cgroup", "r"),
+	}
+	must.Eq(t, expected, paths)
+}
+
+func Test_convert_missing(t *testing.T) {
+	// A non-virtual path that doesn't exist on disk must return an error.
+	_, err := convert([]string{"r:/nonexistent/path/xyz"})
+	must.Error(t, err)
+}
+
+func Test_convert_no_mode(t *testing.T) {
+	// A path with no mode prefix must return an error.
+	_, err := convert([]string{"/proc/cpuinfo"})
+	must.Error(t, err)
 }

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -97,7 +97,7 @@ func init() {
 
 		// invoke the task command with its args
 		// the environment has already been set for us by the exec2 driver;
-		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR.
+		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR
 		cmd := exec.Command(cmdpath, commands[1:]...)
 		cmd.Dir = os.Getenv("NOMAD_WORK_DIR")
 		cmd.Stdout = stdout

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -97,7 +97,7 @@ func init() {
 
 		// invoke the task command with its args
 		// the environment has already been set for us by the exec2 driver;
-		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR
+		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR.
 		cmd := exec.Command(cmdpath, commands[1:]...)
 		cmd.Dir = os.Getenv("NOMAD_WORK_DIR")
 		cmd.Stdout = stdout
@@ -106,15 +106,15 @@ func init() {
 		var code = 0
 		if err = cmd.Run(); err != nil {
 			// cmd.Run() can return errors other than *exec.ExitError — for
-			// example *fs.PathError when chdir into cmd.Dir fails because the
-			// working directory is not unveiled or does not exist. A bare type
+			// example *fs.PathError when chdir into cmd.Dir fails because an
+			// explicit work_dir is not unveiled or does not exist. A bare type
 			// assertion panics in that case; use errors.As instead.
 			var ee *exec.ExitError
 			if errors.As(err, &ee) {
 				code = ee.ExitCode()
 			} else {
 				debug("task command failed: %v", err)
-				code = 1
+				code = subproc.ExitFailure
 			}
 		}
 

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -4,6 +4,7 @@
 package shim
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -104,8 +105,17 @@ func init() {
 
 		var code = 0
 		if err = cmd.Run(); err != nil {
-			ee := err.(*exec.ExitError)
-			code = ee.ExitCode()
+			// cmd.Run() can return errors other than *exec.ExitError — for
+			// example *fs.PathError when chdir into cmd.Dir fails because the
+			// working directory is not unveiled or does not exist. A bare type
+			// assertion panics in that case; use errors.As instead.
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				code = ee.ExitCode()
+			} else {
+				debug("task command failed: %v", err)
+				code = 1
+			}
 		}
 
 		_ = stdout.Close()

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -324,21 +324,21 @@ func TestFunctional_cases(t *testing.T) {
 			user:           "nomad-80000",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		{
 			name:           "run 'env' as nobody without default paths",
 			user:           "nobody",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		{
 			name:           "run 'env' as root without default paths",
 			user:           "root",
 			command:        "/usr/bin/env",
 			unveilDefaults: false,
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		// write to task directory
 		{
@@ -376,7 +376,7 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: false,
 			unveilPaths:    []string{"r:/etc/hosts"},
 			args:           []string{"-c", "cp /etc/hosts ${NOMAD_TASK_DIR}"},
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		{
 			name:           "write to alloc directory no defaults",
@@ -385,7 +385,7 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: false,
 			unveilPaths:    []string{"r:/etc/hosts"},
 			args:           []string{"-c", "cp /etc/hosts ${NOMAD_ALLOC_DIR}"},
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		{
 			name:           "write to secrets directory no defaults",
@@ -394,7 +394,7 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: false,
 			unveilPaths:    []string{"r:/etc/hosts"},
 			args:           []string{"-c", "cp /etc/hosts ${NOMAD_SECRETS_DIR}"},
-			exp:            &drivers.ExitResult{ExitCode: 2},
+			exp:            &drivers.ExitResult{ExitCode: 1},
 		},
 		// dyanmic id
 		{
@@ -484,6 +484,62 @@ func TestFunctional_cases(t *testing.T) {
 			unveilDefaults: true,
 			unveilByTask:   false, // no gate needed — inside sandbox
 			exp:            &drivers.ExitResult{ExitCode: 0},
+		},
+		// /proc/self/mountinfo via explicit task unveil — the reported bug.
+		// Before fix: convert() called os.Stat("/proc/self/mountinfo") which
+		// followed the /proc/self symlink to the shim PID inode; after
+		// unshare --mount-proc the task's private /proc had different inodes,
+		// so Landlock returned EPERM. After fix: stat fails → virtualFSRoot
+		// fires → File rule registered by path string, survives namespace change.
+		{
+			name:           "read /proc/self/mountinfo via task unveil",
+			user:           "nomad-87000",
+			command:        "sh",
+			args:           []string{"-c", "head -1 /proc/self/mountinfo"},
+			unveilDefaults: true,
+			unveilByTask:   true,
+			unveil:         []string{"r:/proc/self/mountinfo"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`\d+ \d+ \d+:\d+`), // mountinfo line format
+		},
+		// /proc/cpuinfo via explicit task unveil.
+		// Before fix: convert() emitted Dir("/proc/cpuinfo","r") — Landlock
+		// rejects Dir on a file inode with EINVAL. After fix: stat succeeds,
+		// IsDir=false → File("/proc/cpuinfo","r") — correct.
+		{
+			name:           "read /proc/cpuinfo via task unveil",
+			user:           "nomad-87000",
+			command:        "sh",
+			args:           []string{"-c", "head -1 /proc/cpuinfo"},
+			unveilDefaults: true,
+			unveilByTask:   true,
+			unveil:         []string{"r:/proc/cpuinfo"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`.+`),
+		},
+		// Multiple specific /proc paths together — mirrors the exact DSE jobspec.
+		{
+			name:           "read multiple /proc paths via task unveil",
+			user:           "nomad-87000",
+			command:        "sh",
+			args:           []string{"-c", "head -1 /proc/self/mountinfo && head -1 /proc/cpuinfo && head -1 /proc/meminfo"},
+			unveilDefaults: true,
+			unveilByTask:   true,
+			unveil:         []string{"r:/proc/self/mountinfo", "r:/proc/cpuinfo", "r:/proc/meminfo"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+		},
+		// /proc root via task unveil — directory form. os.Stat("/proc") succeeds
+		// and IsDir=true so Dir("/proc","r") is emitted; all sub-paths accessible.
+		{
+			name:           "read /proc/self/mountinfo via /proc root unveil",
+			user:           "nomad-87000",
+			command:        "sh",
+			args:           []string{"-c", "head -1 /proc/self/mountinfo && head -1 /proc/cpuinfo"},
+			unveilDefaults: true,
+			unveilByTask:   true,
+			unveil:         []string{"r:/proc"},
+			exp:            &drivers.ExitResult{ExitCode: 0},
+			stdoutRe:       regexp.MustCompile(`\d+ \d+ \d+:\d+`),
 		},
 		// work_dir outside sandbox without unveil_by_task — must be rejected
 		{

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -485,12 +485,8 @@ func TestFunctional_cases(t *testing.T) {
 			unveilByTask:   false, // no gate needed — inside sandbox
 			exp:            &drivers.ExitResult{ExitCode: 0},
 		},
-		// /proc/self/mountinfo via explicit task unveil — the reported bug.
-		// Before fix: convert() called os.Stat("/proc/self/mountinfo") which
-		// followed the /proc/self symlink to the shim PID inode; after
-		// unshare --mount-proc the task's private /proc had different inodes,
-		// so Landlock returned EPERM. After fix: stat fails → virtualFSRoot
-		// fires → File rule registered by path string, survives namespace change.
+		// /proc/self/mountinfo via explicit task unveil
+		// convert() detects /proc/self/* via isProcSelfPath and promotes the entry to Dir("/proc","r")
 		{
 			name:           "read /proc/self/mountinfo via task unveil",
 			user:           "nomad-87000",
@@ -502,10 +498,8 @@ func TestFunctional_cases(t *testing.T) {
 			exp:            &drivers.ExitResult{ExitCode: 0},
 			stdoutRe:       regexp.MustCompile(`\d+ \d+ \d+:\d+`), // mountinfo line format
 		},
-		// /proc/cpuinfo via explicit task unveil.
-		// Before fix: convert() emitted Dir("/proc/cpuinfo","r") — Landlock
-		// rejects Dir on a file inode with EINVAL. After fix: stat succeeds,
-		// IsDir=false → File("/proc/cpuinfo","r") — correct.
+		// /proc/cpuinfo via explicit task unveil
+		// IsDir=false → File("/proc/cpuinfo","r") emitted directly.
 		{
 			name:           "read /proc/cpuinfo via task unveil",
 			user:           "nomad-87000",


### PR DESCRIPTION
Ref: https://hashicorp.atlassian.net/browse/NMD-997

**Problem reported**

A workload running under the exec2 driver received `Permission denied` when reading `/proc/self/mountinfo`, even though the path was explicitly listed in the task's unveil config. No Landlock violations appeared in the audit log — the access was silently blocked from within the sandboxing layer itself.

```
Application error observed (Cassandra / DSE on RHEL 9 and Ubuntu):
java.io.FileNotFoundException: /proc/self/mountinfo (Permission denied)
```

Jobspec that triggered the issue:

```
config {
  command = "/bin/bash"
  args    = ["-c", "${NOMAD_ALLOC_DIR}/dse/dse-6.9.13/bin/dse cassandra -f"]
  unveil  = [
    "r:/proc/cpuinfo",
    "r:/proc/meminfo",
    "r:/proc/self/mountinfo",   # ← failed with permission denied
    "rwc:/var/lib/cassandra",
  ]
}
```

**_Root cause_**

`convert()` called `os.Stat(filepath)` on every unveil entry. For `/proc/self/mountinfo`, `os.Stat` follows the `/proc/self `magic symlink and resolves it to `/proc/<shim-pid>/mountinfo` —> the shim's own PID entry. Landlock locks that specific inode before `unshare --mount-proc` runs. After the unshare, the task's private `/proc` contains completely different inodes; the shim-PID entry no longer exists, so every read returns EPERM.

Paths without symlink indirection — `/proc/cpuinfo`, `/proc/meminfo`, `r:/proc` were unaffected because their inodes are stable across the namespace boundary.

**Fix:**

For any path matching `/proc/self/*` or `/proc/thread-self/*` before calling os.Stat, promote it to `Dir("/proc", mode)`. This is because go-landlock registers rules via `O_PATH` which pins the inode at registration time. /`proc/self` resolves to `/proc/<shim-pid>`, an inode that does not exist in the task's private mount namespace after `unshare --mount-proc`. Pinning it would always produce `EPERM`. Promoting to Dir("/proc", mode) uses the stable /proc directory inode instead, which covers all descendants.

The defaults block also adds `Dir("/proc", "r")` unconditionally when `defaults=true`, so runtimes (JVM, Go) can read `/proc/self/cgroup` and `/proc/self/mountinfo` without needing any explicit unveil entry.


Unveil input | isProcSelfPath? | os.Stat result | Before this PR | After this PR
-- | -- | -- | -- | --
r:/proc/self/mountinfo | yes | skipped | EPERM — File emitted with shim-PID inode; inode gone after unshare --mount-proc | OK — promoted to Dir("/proc","r"); stable directory inode covers all descendants
r:/proc/self/cgroup | yes | skipped | EPERM — same inode problem | OK — promoted to Dir("/proc","r")
r:/proc/thread-self/mountinfo | yes | skipped | EPERM — same inode problem | OK — promoted to Dir("/proc","r")
r:/proc/cpuinfo | no | succeeds — stable regular file | OK — File emitted, inode stable | OK — unchanged, same path
r:/proc | no | succeeds — directory | OK — Dir emitted | OK — unchanged
r:/sys/fs/cgroup | no | succeeds — directory | OK — Dir emitted | OK — unchanged
r:/etc/passwd | no | succeeds — regular file | OK | OK — unchanged
No explicit /proc unveil, unveil_defaults=true | — | — | EPERM — no /proc rule in defaults | OK — Dir("/proc","r") added unconditionally by defaults block



**Testing**
<details>

1)  **unveil_defaults=true, unveil_by_task=true**

```
job "proc-specific-files" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "read-proc" {
      driver = "exec2"

      config {
        command = "/bin/sh"

        args = [
          "-c",
          "echo '=== mountinfo ===' && cat /proc/self/mountinfo | head -3 && echo '=== cpuinfo ===' && head -1 /proc/cpuinfo && echo '=== meminfo ===' && head -1 /proc/meminfo && echo 'ALL OK'"
        ]

        # Specific sub-paths beneath /proc.
        # The virtualFSRoot logic in convert() should resolve these
        # to the stable /proc mount point directly.
        unveil = [
          "r:/proc/self/mountinfo",
          "r:/proc/cpuinfo",
          "r:/proc/meminfo"
        ]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}

```

Result Before:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs --stderr 22ef4a46
cat: /proc/self/mountinfo: Permission denied (os error 13)
```

Result After:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs 10b1b25c
=== mountinfo ===
1079 1076 0:38 /scon/containers/01KS4F7XKHAVX614ZKDHGS499Q/rootfs / rw,noatime master:35 - btrfs /dev/vdb1 rw,nodatasum,nodatacow,ssd,discard,space_cache=v2,subvolid=333,subvol=/scon/containers/01KS4F7XKHAVX614ZKDHGS499Q
1080 1079 0:65 / /dev rw,relatime master:36 - tmpfs none rw,size=492k,mode=755
1081 1080 0:7 /fuse /dev/fuse rw,nosuid,noexec,relatime master:39 - devtmpfs devtmpfs rw,size=8206044k,nr_inodes=2051511,mode=755
=== cpuinfo ===
processor       : 0
=== meminfo ===
MemTotal:       16413624 kB
ALL OK

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs -stderr 10b1b25c
```

**2) **Test for panic  (unveil_defaults=false + command NOT in any unveil list)**
(defaults=false, nothing unveiled → Before: panic(ExitCode 2)→ After: No panic**

```
job "no-defaults-blocked" {
  type = "batch"

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }
    restart {
      attempts = 0
      mode     = "fail"
    }

    task "task" {
      driver = "exec2"

      config {
        command = "/usr/bin/env" // exists on disk but /usr/bin is NOT unveiled
        // no unveil entries → empty Landlock ruleset
        // NOMAD_TASK_DIR also not unveiled → chdir fails with EACCES
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result Before:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs -stderr 2026dc8b
panic: interface conversion: error is *fs.PathError, not *exec.ExitError

goroutine 1 [running]:
github.com/hashicorp/nomad-driver-exec2/pkg/shim.init.0.func1()
        github.com/hashicorp/nomad-driver-exec2/pkg/shim/z_shim_cmd.go:107 +0xd78
github.com/hashicorp/nomad/helper/subproc.Do({0x12bb9fc, 0xa}, 0x130b9c0)
        github.com/hashicorp/nomad@v1.11.3/helper/subproc/subproc.go:39 +0xa0
github.com/hashicorp/nomad-driver-exec2/pkg/shim.init.0()
        github.com/hashicorp/nomad-driver-exec2/pkg/shim/z_shim_cmd.go:46 +0x38
```


Result After:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs --stderr c8578a39
task command failed: open /dev/null: permission denied
```

</details>









<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

