### PR TITLE
Refactor shim parameter passing to use a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 
+* Replaced the positional `os.Args` shim protocol with a versioned JSON config file (`.shim_config.json`) written into `NOMAD_TASK_DIR` before launch.Bumps `handleVersion` to 2; existing running tasks complete naturally before rescheduling. [[GH-101](https://github.com/hashicorp/nomad-driver-exec2/pull/101)]
 * Added optional `work_dir` task config field to override the default CWD. Accepts an absolute path or a path relative to the task directory parent. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
 
 BUG FIXES:

--- a/pkg/shim/config.go
+++ b/pkg/shim/config.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package shim
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// configVersion is the current version of the ShimConfig format.
+// Increment this if the format changes in a backward-incompatible way.
+const configVersion = 1
+
+// ShimConfig holds all parameters the exec2-shim subprocess needs at startup.
+type ShimConfig struct {
+	// Version identifies the config format. Always set to configVersion (1).
+	Version int `json:"version"`
+
+	// UnveilDefaults controls whether the shim should enable the default
+	// Landlock unveil paths (task dir, alloc dir, etc.).
+	UnveilDefaults bool `json:"unveil_defaults"`
+
+	// OutPipe is the filesystem path to the named pipe for task stdout.
+	OutPipe string `json:"out_pipe"`
+
+	// ErrPipe is the filesystem path to the named pipe for task stderr.
+	ErrPipe string `json:"err_pipe"`
+
+	// UID is the numeric user ID the task process should run as.
+	UID int `json:"uid"`
+
+	// GID is the numeric group ID the task process should run as.
+	GID int `json:"gid"`
+
+	// Capabilities is the list of Linux capability names to raise as ambient
+	// capabilities for the task process. Empty means no extra capabilities.
+	Capabilities []string `json:"capabilities"`
+
+	// UnveilPaths is the list of additional Landlock filesystem paths to expose,
+	// in "mode:path" format (e.g. "r:/some/path", "rwxc:/alloc/data").
+	UnveilPaths []string `json:"unveil_paths"`
+
+	// Command is the executable to run as the task process.
+	Command string `json:"command"`
+
+	// Arguments are the command-line arguments passed to Command.
+	Arguments []string `json:"arguments"`
+}
+
+// WriteShimConfig marshals cfg as JSON and atomically writes it to dir/name.
+// All file operations are performed through dir (an os.Root) so that symlinks
+// cannot redirect the write or rename outside the task directory — the same
+// pattern used by fixpipe and openpipe elsewhere in this package.
+// The data is first written to name+".tmp" then renamed into place,
+// so the shim never reads a partially-written file.
+func WriteShimConfig(dir *os.Root, name string, cfg *ShimConfig) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("exec2: marshal shim config: %w", err)
+	}
+
+	tmp := name + ".tmp"
+
+	// root.OpenFile refuses to follow symlinks that escape the root,
+	// preventing a task from redirecting our write to an arbitrary path.
+	f, err := dir.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("exec2: create shim config tmp: %w", err)
+	}
+	_, werr := f.Write(data)
+	cerr := f.Close()
+	if werr != nil {
+		_ = dir.Remove(tmp)
+		return fmt.Errorf("exec2: write shim config tmp: %w", werr)
+	}
+	if cerr != nil {
+		_ = dir.Remove(tmp)
+		return fmt.Errorf("exec2: close shim config tmp: %w", cerr)
+	}
+
+	// Rename within the root — both names are plain basenames so no escape
+	// is possible, and rename(2) replaces the destination atomically.
+	if err = dir.Rename(tmp, name); err != nil {
+		_ = dir.Remove(tmp)
+		return fmt.Errorf("exec2: rename shim config: %w", err)
+	}
+
+	return nil
+}
+
+// ReadShimConfig reads and unmarshals a ShimConfig from path.
+// The returned error wraps fs.ErrNotExist when the file is absent, so callers
+// can distinguish "file not found" from a corrupt or malformed config.
+func ReadShimConfig(path string) (*ShimConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("exec2: read shim config: %w", err)
+	}
+
+	var cfg ShimConfig
+	if err = json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("exec2: unmarshal shim config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/pkg/shim/sandbox.go
+++ b/pkg/shim/sandbox.go
@@ -11,31 +11,6 @@ import (
 	"github.com/shoenig/go-landlock"
 )
 
-// When the nomad binary is invoked as exec2-shim, the format is
-// nomad exec2-shim [path, [...]] -- [commands, [...]]
-// so basically we need to find the first instance of '--' and split on that
-func split(args []string) ([]string, []string) {
-	var (
-		paths    []string
-		commands []string
-	)
-
-	index := 0
-	for ; index < len(args); index++ {
-		if args[index] == "--" {
-			index++
-			break
-		}
-		paths = append(paths, args[index])
-	}
-
-	for ; index < len(args); index++ {
-		commands = append(commands, args[index])
-	}
-
-	return paths, commands
-}
-
 func lockdown(defaults bool, elements []string) error {
 	paths, err := convert(elements)
 	if err != nil {

--- a/pkg/shim/sandbox_test.go
+++ b/pkg/shim/sandbox_test.go
@@ -1,4 +1,0 @@
-// Copyright IBM Corp. 2024, 2026
-// SPDX-License-Identifier: MPL-2.0
-
-package shim

--- a/pkg/shim/sandbox_test.go
+++ b/pkg/shim/sandbox_test.go
@@ -2,39 +2,3 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package shim
-
-import (
-	"testing"
-
-	"github.com/shoenig/test/must"
-)
-
-func Test_split(t *testing.T) {
-	cases := []struct {
-		name  string
-		args  []string
-		paths []string
-		cmds  []string
-	}{
-		{
-			name:  "env",
-			args:  []string{"--", "env"},
-			paths: nil,
-			cmds:  []string{"env"},
-		},
-		{
-			name:  "cat",
-			args:  []string{"/etc/passwd:r", "--", "cat", "/etc/passwd"},
-			paths: []string{"/etc/passwd:r"},
-			cmds:  []string{"cat", "/etc/passwd"},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			paths, cmds := split(tc.args)
-			must.Eq(t, tc.paths, paths)
-			must.Eq(t, tc.cmds, cmds)
-		})
-	}
-}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -151,8 +151,14 @@ func (e *exe) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to set logging pipe ownership: %w", err)
 	}
 
+	// write shim config file
+	configPath, err := e.writeShimConfig(uid, gid)
+	if err != nil {
+		return fmt.Errorf("failed to write shim config: %w", err)
+	}
+
 	// create sandbox using nsenter, unshare, and our cgroup
-	cmd, err := e.prepare(ctx, home, fd, uid, gid)
+	cmd, err := e.prepare(ctx, home, fd, configPath)
 	if err != nil {
 		return err
 	}
@@ -360,7 +366,70 @@ func self() string {
 	return executable
 }
 
-func (e *exe) parameters(uid, gid int) []string {
+// writeShimConfig serializes all shim startup parameters into a JSON config
+// file at <NOMAD_TASK_DIR>/.shim_config.json and returns its path.
+// The file is written into NOMAD_TASK_DIR (the "local/" subdirectory) rather
+// than TaskDir (the parent) so it is co-located with .exit_status.txt and
+// accessible to tasks via ${NOMAD_TASK_DIR}/.shim_config.json.
+// The path is also appended as an "r:" unveil entry so Landlock permits the
+// shim to read it before the sandbox is engaged.
+//
+// All file operations (write, rename, chown) are performed through an
+// os.Root opened on taskDir so that symlinks cannot redirect them outside
+// the task directory — the same pattern used by fixpipe.
+func (e *exe) writeShimConfig(uid, gid int) (string, error) {
+	taskDir := e.env.Env["NOMAD_TASK_DIR"]
+	if taskDir == "" {
+		return "", fmt.Errorf("NOMAD_TASK_DIR is not set in task environment")
+	}
+
+	const name = ".shim_config.json"
+	path := filepath.Join(taskDir, name)
+
+	// Open the task directory as a root so every subsequent operation is
+	// confined to it — mirrors the fixpipe / openpipe pattern.
+	root, err := os.OpenRoot(taskDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to open task dir for shim config: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// copy unveil paths into a new slice to avoid mutating the shared
+	// Options.UnveilPaths backing array, then add the config file itself
+	unveilPaths := make([]string, len(e.opts.UnveilPaths), len(e.opts.UnveilPaths)+1)
+	copy(unveilPaths, e.opts.UnveilPaths)
+	unveilPaths = append(unveilPaths, "r:"+path)
+
+	cfg := &ShimConfig{
+		Version:        configVersion,
+		UnveilDefaults: e.opts.UnveilDefaults,
+		OutPipe:        e.env.OutPipe,
+		ErrPipe:        e.env.ErrPipe,
+		UID:            uid,
+		GID:            gid,
+		Capabilities:   e.opts.Capabilities,
+		UnveilPaths:    unveilPaths,
+		Command:        e.opts.Command,
+		Arguments:      e.opts.Arguments,
+	}
+
+	if err := WriteShimConfig(root, name, cfg); err != nil {
+		return "", err
+	}
+
+	// chown the config file to the task user so the task process can read it;
+	// the file stays 0o600 so other users on the host cannot access it.
+	// root.Chown uses the basename inside the root rather than a bare
+	// os.Chown so a pre-placed symlink in taskDir cannot redirect the
+	// ownership change outside the allocation directory.
+	if err := root.Chown(name, uid, gid); err != nil {
+		return "", fmt.Errorf("failed to chown shim config: %w", err)
+	}
+
+	return path, nil
+}
+
+func (e *exe) parameters(configPath string) []string {
 	var result []string
 
 	// setup nsenter if task was assigned a network namespace
@@ -388,33 +457,15 @@ func (e *exe) parameters(uid, gid int) []string {
 		"--",
 	)
 
-	// setup ourself '$0 exec2-shim' for unveil
-	result = append(result, self(), SubCommand)
-	result = append(result, strconv.FormatBool(e.opts.UnveilDefaults))
-	result = append(result, e.env.OutPipe)
-	result = append(result, e.env.ErrPipe)
-	// pass uid and gid so the shim can drop privileges itself (after fork,
-	// before exec) with PR_SET_KEEPCAPS to preserve the ambient capability set
-	result = append(result, strconv.Itoa(uid))
-	result = append(result, strconv.Itoa(gid))
-	// pass capability names as a comma-separated string; empty means no caps
-	result = append(result, strings.Join(e.opts.Capabilities, ","))
-	result = append(result, e.opts.UnveilPaths...)
-	result = append(result, "--")
-
-	// append the user command
-	result = append(result, e.opts.Command)
-	if len(e.opts.Arguments) > 0 {
-		result = append(result, e.opts.Arguments...)
-	}
-
 	// craft complete result
+	result = append(result, self(), SubCommand, configPath)
+
 	return result
 }
 
 // create an exec.Cmd to run our process tree
-func (e *exe) prepare(ctx context.Context, home string, fd, uid, gid int) (*exec.Cmd, error) {
-	params := e.parameters(uid, gid)
+func (e *exe) prepare(ctx context.Context, home string, fd int, configPath string) (*exec.Cmd, error) {
+	params := e.parameters(configPath)
 	cmd := exec.CommandContext(ctx, params[0], params[1:]...)
 
 	// Open the pipes via os.Root so that the open is resolved relative to

--- a/pkg/shim/z_shim_cmd.go
+++ b/pkg/shim/z_shim_cmd.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -50,22 +49,19 @@ const (
 	// ExitBadLogging indicates the shim has terminated early due to being unable
 	// to open stdout or stderr output files (fifos).
 	ExitBadLogging = 41
+
+	// ExitBadConfig indicates the shim has terminated early due to being unable
+	// to read or parse the shim config file.
+	ExitBadConfig = 42
 )
 
 // init is the entrypoint for the 'nomad exec2-shim' invocation of nomad
 //
 // The argument format is as follows,
 //
-// 0. nomad            <- the executable name
-// 1. exec2-shim       <- this subcommand
-// 2. true/false       <- include default unveil paths
-// 3. <stdout path>    <- path to named pipe for standard output
-// 4. <stderr path>    <- path to named pipe for standard error
-// 5. <uid>            <- numeric user id for the task process
-// 6. <gid>            <- numeric group id for the task process
-// 7. cap,cap,...      <- comma-separated ambient capability names (empty string if none)
-// 8. [mode:path, ...] <- list of additional unveil paths
-// 9. --               <- sentinel between following commands
+//	0. nomad              <- the executable name
+//	1. exec2-shim         <- this subcommand
+//	2. <config file path> <- path to the JSON ShimConfig written by the driver
 func init() {
 	subproc.Do(SubCommand, func() int {
 		// we need to ignore the stop signal (which is sent to the entire
@@ -77,50 +73,42 @@ func init() {
 			<-sigs // do nothing; stay alive
 		}()
 
-		if n := len(os.Args); n <= 7 {
-			subproc.Print("failed to invoke exec2-shim with sufficient args: %d", n)
+		if len(os.Args) != 3 {
+			subproc.Print("exec2-shim requires exactly 1 argument (config path), got %d", len(os.Args)-2)
 			return ExitWrongArgs
 		}
 
-		defaults := os.Args[2] == "true"
-		outPipePath := os.Args[3]
-		errPipePath := os.Args[4]
-		uid, err := strconv.Atoi(os.Args[5])
+		cfg, err := ReadShimConfig(os.Args[2])
 		if err != nil {
-			subproc.Print("invalid uid %q: %v", os.Args[5], err)
-			return ExitWrongArgs
+			subproc.Print("failed to read shim config %q: %v", os.Args[2], err)
+			return ExitBadConfig
 		}
-		gid, err := strconv.Atoi(os.Args[6])
-		if err != nil {
-			subproc.Print("invalid gid %q: %v", os.Args[6], err)
-			return ExitWrongArgs
-		}
-		capsArg := os.Args[7]
 
-		// get the unveil paths and the rest of the command(s) to run
-		// from our command arguments (after uid, gid, and caps args)
-		args := os.Args[8:]
-		paths, commands := split(args)
-		paths = append(paths, "w:"+outPipePath)
-		paths = append(paths, "w:"+errPipePath)
+		outPipePath := cfg.OutPipe
+		errPipePath := cfg.ErrPipe
+
+		// copy unveil paths into a new slice to avoid mutating cfg.UnveilPaths,
+		// then append the write entries for stdout/stderr pipes
+		paths := make([]string, len(cfg.UnveilPaths), len(cfg.UnveilPaths)+2)
+		copy(paths, cfg.UnveilPaths)
+		paths = append(paths, "w:"+outPipePath, "w:"+errPipePath)
 
 		// resolve capability names to kernel integers before calling dropPrivileges;
 		// this is a pure string-to-integer mapping that requires no privileges
 		var caps []uintptr
-		if capsArg != "" {
-			capNames := strings.Split(capsArg, ",")
+		if len(cfg.Capabilities) > 0 {
 			var capErr error
-			caps, capErr = capabilities.Resolve(capNames)
+			caps, capErr = capabilities.Resolve(cfg.Capabilities)
 			if capErr != nil {
 				subproc.Print("failed to resolve capabilities: %v", capErr)
-				return ExitWrongArgs
+				return ExitBadConfig
 			}
 		}
 
 		// drop privileges conditionally: for non-root tasks, transitions uid/gid;
 		// for tasks with caps, restores them in permitted/effective/inheritable and
 		// raises as ambient so they survive into the task process via exec().
-		if err := dropPrivileges(uid, gid, caps); err != nil {
+		if err := dropPrivileges(cfg.UID, cfg.GID, caps); err != nil {
 			subproc.Print("failed to drop privileges: %v", err)
 			return subproc.ExitFailure
 		}
@@ -138,16 +126,16 @@ func init() {
 
 		// use landlock to isolate this process and child processes to the
 		// set of given filepaths
-		if err := lockdown(defaults, paths); err != nil {
+		if err := lockdown(cfg.UnveilDefaults, paths); err != nil {
 			debug("unable to lockdown: %v", err)
 			return subproc.ExitFailure
 		}
 
 		// locate the absolute path for the task command, as this must be
 		// the first argument to the execve(2) call that follows
-		cmdpath, err := exec.LookPath(commands[0])
+		cmdpath, err := exec.LookPath(cfg.Command)
 		if err != nil {
-			debug("failed to locate command %q: %v", commands[0], err)
+			debug("failed to locate command %q: %v", cfg.Command, err)
 			return subproc.ExitNotRunnable
 		}
 
@@ -157,7 +145,7 @@ func init() {
 		
 		// the environment has already been set for us by the exec2 driver;
 		// NOMAD_WORK_DIR is set to work_dir if configured, otherwise NOMAD_TASK_DIR
-		cmd := exec.Command(cmdpath, commands[1:]...)
+		cmd := exec.Command(cmdpath, cfg.Arguments...)
 		cmd.Dir = os.Getenv("NOMAD_WORK_DIR")
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr

--- a/plugin/about.go
+++ b/plugin/about.go
@@ -17,7 +17,7 @@ import (
 const (
 	name          = "exec2"
 	version       = "v2.0.0"
-	handleVersion = 1
+	handleVersion = 2
 
 	// allowCapsDefault is the default set of Linux capabilities the exec2
 	// driver permits tasks to request, expressed as an HCL literal for use


### PR DESCRIPTION
Fixes: https://hashicorp.atlassian.net/browse/NMD-1694

**Summary**

The exec2 driver launches tasks via a exec2-shim subprocess. Previously every parameter (uid, gid, pipes, capabilities, unveil paths, command, args) was packed into os.Args as a positional list — a fragile, order-sensitive protocol.

This PR replaces that protocol with a JSON config file (`.shim_config.json`) written by the driver into `NOMAD_TASK_DIR` before the shim is launched, mirroring how `runc` uses config.json. The shim receives a single argument: the path to that file.

> Zero behaviour change for running tasks. The only visible difference is handleVersion 1 → 2, which causes Nomad to cleanly reschedule any tasks that were started by the old binary when the agent restarts.

**Config File — Filesystem Location**

```
/tmp/NomadClient1/
├── alloc/
│   └── <alloc-id>/
│       ├── <task-name>/
│       │   ├── local/          ← NOMAD_TASK_DIR
│       │   │   ├── .shim_config.json   ✅ WE WRITE THIS (via os.Root)
│       │   │   └── .exit_status.txt    (pre-existing, written by shim after exit)
│       │   └── logs/
│       │       ├── task.stdout.fifo    (pre-existing, chowned by fixpipe)
│       │       └── task.stderr.fifo    (pre-existing, chowned by fixpipe)
│       └── tmp/
└── ...
```

The file is written to `NOMAD_TASK_DIR` (the `local/ subdir`), not the parent TaskDir. It is readable by the task process as `${NOMAD_TASK_DIR}/.shim_config.json`. Permissions are `0o600`, chowned to the dynamic workload user (e.g. `nomad-42317`).

**Example — a typical task config file on disk:**

```
{
  "version":1,
  "unveil_defaults":true,
  "out_pipe":"/tmp/NomadClient1/alloc/abc123/logs/web.stdout.fifo",
  "err_pipe":"/tmp/NomadClient1/alloc/abc123/logs/web.stderr.fifo",
  "uid":60042, "gid":60042,
  "capabilities":["net_bind_service"],
  "unveil_paths":["r:/etc/ssl/certs","r:/tmp/NomadClient1/alloc/abc123/web/local/.shim_config.json"],
  "command":"/usr/local/bin/web",
  "arguments":["--port","80"]
}
```

`handleVersion 1 → 2`: When the new binary is deployed, Nomad detects the version mismatch on agent restart and reschedules any tasks that were started by the old binary. Tasks launched by the new binary use the config-file protocol exclusively. There is no mixed-version fallback — the old positional protocol has been fully removed.

**Testing**
<details>

1) **Confirms that the shim is now invoked with the config file path, and that the config file exists and contains the expected JSON.**
```
job "sleep" {
  type = "service"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "sleep" {
      driver = "exec2"

      config {
        command = "sleep"
        args    = ["infinity"]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:
```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad job run jobs/sleep.hcl
==> 2026-08-25T12:55:45+05:30: Monitoring evaluation "61ff1536"
    2026-08-25T12:55:45+05:30: Evaluation triggered by job "sleep"
    2026-08-25T12:55:46+05:30: Evaluation within deployment: "78a94875"
    2026-08-25T12:55:46+05:30: Allocation "d4a149f7" created: node "d67b220a", group "group"
    2026-08-25T12:55:46+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-25T12:55:46+05:30: Evaluation "61ff1536" finished with status "complete"
==> 2026-08-25T12:55:46+05:30: Monitoring deployment "78a94875"
  ✓ Deployment "78a94875" successful
    
    2026-08-25T12:55:56+05:30
    ID          = 78a94875
    Job ID      = sleep
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    group       1        1       1        0          2026-08-25T13:05:55+05:30

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ ALLOC_SLEEP=$(nomad job status sleep | awk '/^[0-9a-f]{8}/{print $1; exit}')
sudo cat /proc/$(pgrep -f 'nomad-driver-exec2 exec2-shim' | head -1)/cmdline | tr '\0' ' '
unshare --ipc --pid --mount-proc --propagation slave --fork --kill-child=SIGKILL -- /tmp/nomad-plugins/nomad-driver-e xec2 exec2-shim /tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/local/.shim_config.json 

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad alloc fs "$ALLOC_SLEEP" sleep/local/.shim_config.json | python3 -m json.tool
{
    "version": 1,
    "unveil_defaults": true,
    "out_pipe": "/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/alloc/logs/.sleep.stdout.fifo",
    "err_pipe": "/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/alloc/logs/.sleep.stderr.fifo",
    "uid": 87515,
    "gid": 87515,
    "capabilities": [],
    "unveil_paths": [
        "r:/etc/mime.types",
        "r:/sys/fs/cgroup/nomad.slice/share.slice/d4a149f7-5729-e613-deec-eaba5dcc306c.sleep.scope",
        "rwxc:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/local",
        "rwxc:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/alloc",
        "rx:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/alloc/logs",
        "rwxc:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/secrets",
        "rwxc:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/tmp",
        "r:/tmp/NomadClient2490179035/d4a149f7-5729-e613-deec-eaba5dcc306c-sleep/local/.shim_config.json"
    ],
    "command": "sleep",
    "arguments": [
        "infinity"
    ]
}

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad alloc fs "$ALLOC_SLEEP" sleep/local/.shim_config.json \
  | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['version']==1, d['version']; print('version OK:', d['version'])"
version OK: 1
```

2) **This job runs cat directly on the .shim_config.json file, confirming the task can read it (Landlock permits `r:<configpath>`) and that it is non-empty.**

```
job "shim-config" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "inspect" {
      driver = "exec2"

      config {
        # NOMAD_TASK_DIR is unveiled rwxc by unveil_defaults; cat is in /bin (rx).
        # No extra unveil needed.
        command = "cat"
        args    = ["${NOMAD_TASK_DIR}/.shim_config.json"]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad job run jobs/shim-config.hcl
==> 2026-08-25T12:50:24+05:30: Monitoring evaluation "22d4a268"
    2026-08-25T12:50:25+05:30: Evaluation triggered by job "shim-config"
    2026-08-25T12:50:26+05:30: Allocation "8b0e0596" created: node "d67b220a", group "group"
    2026-08-25T12:50:26+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-25T12:50:26+05:30: Evaluation "22d4a268" finished with status "complete"

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ ALLOC=$(nomad job status shim-config | grep -oP '[0-9a-f]{8}(?=\s+[0-9a-f]{8}\s+group)' | head -1)
nomad alloc logs "$ALLOC"
{"version":1,"unveil_defaults":true,"out_pipe":"/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/alloc/logs/.inspect.stdout.fifo","err_pipe":"/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/alloc/logs/.inspect.stderr.fifo","uid":82742,"gid":82742,"capabilities":[],"unveil_paths":["r:/etc/mime.types","r:/sys/fs/cgroup/nomad.slice/share.slice/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526.inspect.scope","rwxc:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/local","rwxc:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/alloc","rx:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/alloc/logs","rwxc:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/secrets","rwxc:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/tmp","r:/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-87c5013f5526-inspect/local/.shim_config.json"],"command":"cat","arguments":["/tmp/NomadClient2490179035/8b0e0596-fcf1-dfe3-ae2a-8
```

3) **Verifies that cap_add entries survive the JSON serialization round-trip and arrive as ambient capabilities in the task process.**

```
job "caps" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "caps" {
      driver = "exec2"

      config {
        command = "grep"
        args    = ["CapAmb", "/proc/self/status"]
        cap_add = ["net_bind_service"]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad job run jobs/caps.hcl
==> 2026-08-25T12:52:36+05:30: Monitoring evaluation "15575c7a"
    2026-08-25T12:52:36+05:30: Evaluation triggered by job "caps"
    2026-08-25T12:52:37+05:30: Allocation "820f799e" created: node "d67b220a", group "group"
    2026-08-25T12:52:37+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-25T12:52:37+05:30: Evaluation "15575c7a" finished with status "complete"

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ ALLOC=$(nomad job status caps | grep -oP '[0-9a-f]{8}(?=\s+[0-9a-f]{8}\s+group)' | head -1)
nomad alloc logs "$ALLOC"
CapAmb: 0000000000000400
```

4) **Verifies that work_dir = "local" is correctly serialized into the config file.**

```
job "workdir" {
  type = "batch"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 0
      mode     = "fail"
    }

    task "pwd" {
      driver = "exec2"

      config {
        command  = "pwd"
        # "local" resolves to <alloc>/<task>/local which is inside the alloc
        # dir, already unveiled rwxc by unveil_defaults. No extra unveil needed.
        work_dir = "local"
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result:

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ nomad job run jobs/workdir.hcl
==> 2026-08-25T12:53:48+05:30: Monitoring evaluation "7d05cfe3"
    2026-08-25T12:53:48+05:30: Evaluation triggered by job "workdir"
    2026-08-25T12:53:49+05:30: Allocation "4dd09275" created: node "d67b220a", group "group"
    2026-08-25T12:53:49+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-08-25T12:53:49+05:30: Evaluation "7d05cfe3" finished with status "complete"

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2/e2e$ ALLOC=$(nomad job status workdir | grep -oP '[0-9a-f]{8}(?=\s+[0-9a-f]{8}\s+group)' | head -1)
nomad alloc logs "$ALLOC"
/tmp/NomadClient2490179035/4dd09275-c960-84bd-25e9-4e691ca2d7c7-pwd/local
```









</details>


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

