### PR TITLE
fix: recover task after host reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* Fixed tasks failing to start after a host reboot. [[GH-104](https://github.com/hashicorp/nomad-driver-exec2/pull/104)]
 * Fixed mount propagation so host mounts remain visible while task-internal mounts stay isolated from the host. [[GH-99](https://github.com/hashicorp/nomad-driver-exec2/pull/99)]
 * Fixed `GOMAXPROCS` to prevent Go workloads from being over-threaded against the host CPU capacity. [[GH-98](https://github.com/hashicorp/nomad-driver-exec2/pull/98)]
 * Error messages from the `unshare`/`nsenter` shim processes now appear in the allocation logs. [[GH-95](https://github.com/hashicorp/nomad-driver-exec2/pull/95)]

--- a/pkg/shim/sandbox_test.go
+++ b/pkg/shim/sandbox_test.go
@@ -4,10 +4,64 @@
 package shim
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shoenig/test/must"
 )
+
+// verifies that fixpipe recreates the logs directory and FIFO 
+// when the entire alloc-mounts directory is gone, as happens after a host reboot.
+func Test_fixpipe_missing_dir(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root privileges")
+	}
+
+	// path whose parent directory does NOT exist — the exact post-reboot state
+	dir := filepath.Join(t.TempDir(), "alloc", "logs")
+	path := filepath.Join(dir, ".task.stdout.fifo")
+
+	must.NoError(t, fixpipe(path, os.Getuid(), os.Getgid()))
+
+	info, err := os.Stat(path)
+	must.NoError(t, err)
+	must.True(t, info.Mode()&os.ModeNamedPipe != 0, must.Sprint("expected a named pipe"))
+}
+
+// verifies that fixpipe recreates the FIFO when the
+// parent directory exists but the FIFO file itself is missing.
+func Test_fixpipe_missing_fifo(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root privileges")
+	}
+
+	dir := filepath.Join(t.TempDir(), "alloc", "logs")
+	must.NoError(t, os.MkdirAll(dir, 0o777))
+	path := filepath.Join(dir, ".task.stdout.fifo")
+
+	// directory exists but FIFO does not
+	must.NoError(t, fixpipe(path, os.Getuid(), os.Getgid()))
+
+	info, err := os.Stat(path)
+	must.NoError(t, err)
+	must.True(t, info.Mode()&os.ModeNamedPipe != 0, must.Sprint("expected a named pipe"))
+}
+
+// verifies that calling fixpipe when the FIFO already
+// exists (the normal non-reboot path) does not return an error.
+func Test_fixpipe_idempotent(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root privileges")
+	}
+
+	dir := filepath.Join(t.TempDir(), "alloc", "logs")
+	path := filepath.Join(dir, ".task.stdout.fifo")
+
+	must.NoError(t, fixpipe(path, os.Getuid(), os.Getgid()))
+	// calling again must not error — FIFO already exists
+	must.NoError(t, fixpipe(path, os.Getuid(), os.Getgid()))
+}
 
 func Test_split(t *testing.T) {
 	cases := []struct {

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -209,6 +209,17 @@ func fixpipe(path string, uid, gid int) error {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
 
+	// After a host reboot the alloc-mounts bind mount is gone; recreate the
+	// logs directory and FIFO before attempting to chown either of them.
+	// Use 0o777 to match the permissions Nomad sets when it creates the logs
+	// directory in allocdir (SharedAllocDirs are created with fileMode777).
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return fmt.Errorf("error creating fifo parent directory %q: %w", dir, err)
+	}
+	if err := unix.Mkfifo(path, 0o600); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("error creating fifo %q: %w", path, err)
+	}
+
 	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return fmt.Errorf("error opening fifo parent directory %q: %w", dir, err)


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/63

**_Summary_**

After a host reboot, any exec2 task whose alloc was previously running fails to restart with a Driver Failure logged by Nomad:

```
Error from Nomad allocation events
rpc error: code = Unknown desc = failed to start task: failed to set logging pipe ownership: chown /var/nomad/alloc_mounts/<alloc-id>/alloc/logs/.http.stdout.fifo: no such file or directory
```

The alloc remains in pending → failed and does not self-recover without operator intervention (stop + re-run the job).

**_Root Cause_**

The exec2 driver creates a logging FIFO for each task and calls `fixpipe()` in `pkg/shim/shim.go` to chown those FIFOs to the task's user before starting the sandboxed process. The call chain is:

```
StartTask()
  └─ runner.Start()
       └─ e.fixPipes(uid, gid)
            └─ fixpipe(path, uid, gid)   ← the bug 
                 └─ os.OpenRoot(dir)     ← fails if dir is gone
```

The `alloc/logs/` directory lives inside the alloc_mounts bind mount. The OS tears down all bind mounts on every reboot, so the directory  and the FIFOs inside it are gone when Nomad tries to restart the task.

fixpipe called `os.OpenRoot(dir)` unconditionally, without first ensuring the directory and FIFO existed. This produced two failure variants depending on how far the bind mount had been reconstructed:

Variant | Post-reboot state | Failure site | Error text
-- | -- | -- | --
A | Entire alloc/logs/ directory missing | os.OpenRoot(dir) | no such file or directory (on dir)
B (reported) | Directory exists; FIFO file missing | root.Chown(base, …) | chown …/.stdout.fifo: no such file or directory

<br class="Apple-interchange-newline">

`The key point: ` the directory entry for `alloc/logs/ `may survive on disk (if data_dir is on persistent storage), but the bind mount on top of it is always torn down by the kernel on reboot. When Nomad remounts it, it starts empty, the FIFOs are gone.

So the bug hits in production regardless of whether `data_dir` is on tmpfs or persistent disk, because it is the bind mount lifecycle, not the underlying filesystem, that wipes the FIFOs.

**_Testing_**

<details>

1) 
**agent.hcl**

```
# Non-dev agent config for full end-to-end GH-63 reproduction.
# data_dir is on persistent btrfs (/var/lib/nomad) so Nomad state survives
# a simulated reboot (wiping /tmp). The alloc dirs still land in /tmp
# (tmpfs), which is exactly what the bug requires.

data_dir   = "/var/lib/nomad"
bind_addr  = "0.0.0.0"
plugin_dir = "/var/lib/nomad-plugins"

server {
  enabled          = true
  bootstrap_expect = 1
  default_scheduler_config {
    memory_oversubscription_enabled = true
  }
}

ui {
  enabled=true
  show_cli_hints = false
}

client {
  enabled = true
  # keep alloc dirs under /tmp so they ARE wiped on reboot — that's the bug
  state_dir = "/var/lib/nomad/client"
  options = {
    "fingerprint.denylist" = "env_aws,env_gce,env_azure,env_digitalocean"
  }
}

plugin "nomad-driver-exec2" {
  config {
    unveil_by_task = true
    unveil_paths   = ["r:/etc/mime.types"]
  }
}
```

**job:**
```
# Long-running service job used to reproduce the bug.
# The writer task prints "alive at <time>" every 2 seconds so you can
# confirm logs are flowing before and after the simulated reboot.

job "reboot-test" {
  type = "service"

  constraint {
    attribute = "${attr.kernel.name}"
    value     = "linux"
  }

  group "group" {
    reschedule {
      attempts  = 0
      unlimited = false
    }

    restart {
      attempts = 3
      delay    = "5s"
      mode     = "delay"
    }

    task "writer" {
      driver = "exec2"

      config {
        command = "/bin/sh"
        args    = ["-c", "while true; do echo \"alive at $(date)\"; sleep 2; done"]
      }

      resources {
        cpu    = 100
        memory = 32
      }
    }
  }
}
```

Result Before:

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad job run e2e/jobs/reboot-test.hcl
sleep 8
ALLOC=$(nomad job status reboot-test | grep -E '^[a-f0-9]{8}' | awk '{print $1}' | head -1)
echo "Alloc ID: $ALLOC"
nomad alloc status "$ALLOC" | grep 'Client Status'
==> 2026-09-01T13:19:58+05:30: Monitoring evaluation "45c1fda0"
    2026-09-01T13:19:58+05:30: Evaluation triggered by job "reboot-test"
    2026-09-01T13:19:59+05:30: Evaluation within deployment: "defb2645"
    2026-09-01T13:19:59+05:30: Allocation "e2783f48" created: node "6ad44a0c", group "group"
    2026-09-01T13:19:59+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-09-01T13:19:59+05:30: Evaluation "45c1fda0" finished with status "complete"
==> 2026-09-01T13:19:59+05:30: Monitoring deployment "defb2645"
  ✓ Deployment "defb2645" successful
    
    2026-09-01T13:20:10+05:30
    ID          = defb2645
    Job ID      = reboot-test
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    group       1        1       1        0          2026-09-01T13:30:08+05:30
Alloc ID: e2783f48
Client Status       = running

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ nomad alloc logs "$ALLOC" writer
alive at Tue Sep  1 13:19:59 IST 2026
alive at Tue Sep  1 13:20:01 IST 2026
alive at Tue Sep  1 13:20:03 IST 2026
alive at Tue Sep  1 13:20:05 IST 2026
alive at Tue Sep  1 13:20:07 IST 2026
alive at Tue Sep  1 13:20:10 IST 2026
alive at Tue Sep  1 13:20:12 IST 2026
alive at Tue Sep  1 13:20:14 IST 2026
alive at Tue Sep  1 13:20:16 IST 2026
alive at Tue Sep  1 13:20:18 IST 2026
alive at Tue Sep  1 13:20:20 IST 2026
alive at Tue Sep  1 13:20:22 IST 2026
alive at Tue Sep  1 13:20:25 IST 2026
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ sudo find /tmp/nomad-alloc-mounts -name '*.fifo' | head -4
/tmp/nomad-alloc-mounts/e2783f48-8760-8dfa-9ada-b3058e6232ca-writer/alloc/logs/.writer.stdout.fifo
/tmp/nomad-alloc-mounts/e2783f48-8760-8dfa-9ada-b3058e6232ca-writer/alloc/logs/.writer.stderr.fifo

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ ls /tmp/nomad-alloc-mounts/ 2>/dev/null && echo "STILL THERE — try again" \
  || echo "Wiped ✓"
Wiped ✓

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ sudo find /var/lib/nomad/client -type f
/var/lib/nomad/client/state.db
/var/lib/nomad/client/client-id
/var/lib/nomad/client/secret-id

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ pgrep -fa exec2-shim || echo "No shim — dead ✓"
pgrep -fa 'sh -c while true' || echo "No writer — dead ✓"
No shim — dead ✓
No writer — dead ✓

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ ALLOC=$(sudo cat /var/lib/nomad/gh63_alloc_id)
echo "Alloc: $ALLOC"
nomad alloc status "$ALLOC"
Alloc: e2783f48
ID                  = e2783f48-8760-8dfa-9ada-b3058e6232ca
Eval ID             = 45c1fda0
Name                = reboot-test.group[0]
Node ID             = 6ad44a0c
Node Name           = podman-dev
Job ID              = reboot-test
Job Version         = 0
Client Status       = failed
Client Description  = Failed tasks
Desired Status      = run
Desired Description = <none>
Created             = 5m6s ago
Modified            = 34s ago
Deployment ID       = defb2645
Deployment Health   = healthy

Task "writer" is "dead"
Task Resources:
CPU      Memory  Disk     Addresses
100 MHz  32 MiB  300 MiB  

Task Events:
Started At     = 2026-09-01T07:49:58Z
Finished At    = 2026-09-01T07:54:17Z
Total Restarts = 1
Last Restart   = 2026-09-01T13:24:12+05:30

Recent Events:
Time                       Type            Description
2026-09-01T13:24:17+05:30  Not Restarting  Error was unrecoverable
2026-09-01T13:24:17+05:30  Driver Failure  rpc error: code = Unknown desc = failed to start task: failed to set logging pipe ownership: error opening fifo parent directory "/tmp/nomad-alloc-mounts/e2783f48-8760-8dfa-9ada-b3058e6232ca-writer/alloc/logs": open /tmp/nomad-alloc-mounts/e2783f48-8760-8dfa-9ada-b3058e6232ca-writer/alloc/logs: no such file or directory
2026-09-01T13:24:12+05:30  Restarting      Task restarting in 5.096576379s
2026-09-01T13:24:12+05:30  Terminated      Exit Code: -1
2026-09-01T13:19:58+05:30  Started         Task started by client
2026-09-01T13:19:58+05:30  Task Setup      Building Task Directory
2026-09-01T13:19:58+05:30  Received        Task received by client
```



**Result After:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ # Submit job, confirm running
nomad job run e2e/jobs/reboot-test.hcl
sleep 10

ALLOC=$(nomad job status reboot-test | grep -E '^[a-f0-9]{8}' | awk '{print $1}' | head -1)
echo "Alloc: $ALLOC"
nomad alloc status "$ALLOC" | grep 'Client Status'
==> 2026-09-01T17:41:59+05:30: Monitoring evaluation "adda3412"
    2026-09-01T17:41:59+05:30: Evaluation triggered by job "reboot-test"
    2026-09-01T17:42:00+05:30: Evaluation within deployment: "b95a183e"
    2026-09-01T17:42:00+05:30: Allocation "23fc545e" created: node "6a3f4f20", group "group"
    2026-09-01T17:42:00+05:30: Evaluation status changed: "pending" -> "complete"
==> 2026-09-01T17:42:00+05:30: Evaluation "adda3412" finished with status "complete"
==> 2026-09-01T17:42:00+05:30: Monitoring deployment "b95a183e"
  ✓ Deployment "b95a183e" successful
    
    2026-09-01T17:42:10+05:30
    ID          = b95a183e
    Job ID      = reboot-test
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully
    
    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    group       1        1       1        0          2026-09-01T17:52:09+05:30
Alloc: 23fc545e
Client Status       = running

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ # Confirm FIFOs in /tmp and state.db on disk
sudo find /tmp/nomad-alloc-mounts -name '*.fifo' | head -2
sudo find /var/lib/nomad/client -type f

# Save alloc ID for after the reboot
sudo bash -c "echo $ALLOC > /var/lib/nomad/gh63_alloc_id"
/tmp/nomad-alloc-mounts/23fc545e-21ce-6fed-6274-e8b3acd1077c-writer/alloc/logs/.writer.stdout.fifo
/tmp/nomad-alloc-mounts/23fc545e-21ce-6fed-6274-e8b3acd1077c-writer/alloc/logs/.writer.stderr.fifo
/var/lib/nomad/client/state.db
/var/lib/nomad/client/client-id
/var/lib/nomad/client/secret-id

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ # Wait for exec2
for i in $(seq 1 20); do
  nomad node status -self -verbose 2>/dev/null | grep -q exec2 && echo "ready ✓" && break
  echo "waiting... ($i)"; sleep 3
done

ALLOC=$(sudo cat /var/lib/nomad/gh63_alloc_id)
echo "Alloc: $ALLOC"
nomad alloc status "$ALLOC" | grep 'Client Status'
nomad alloc status "$ALLOC" | grep -A10 'Recent Events'
ready ✓
Alloc: 23fc545e
Client Status       = running
Recent Events:
Time                       Type        Description
2026-09-01T17:41:59+05:30  Started     Task started by client
2026-09-01T17:41:59+05:30  Task Setup  Building Task Directory
2026-09-01T17:41:59+05:30  Received    Task received by client
```

</details>








<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

