### PR TITLE
extract RSS value from cgroup data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BREAKING CHANGES:
 IMPROVEMENTS:
 
 * Added optional `work_dir` task config field to override the default CWD. Accepts an absolute path or a path relative to the task directory parent. [[GH-97](https://github.com/hashicorp/nomad-driver-exec2/pull/97)]
+* Task memory stats now include RSS on cgroups v2 systems. [[GH-105](https://github.com/hashicorp/nomad-driver-exec2/pull/105)]
 
 BUG FIXES:
 

--- a/pkg/resources/utilization.go
+++ b/pkg/resources/utilization.go
@@ -18,6 +18,7 @@ type Utilization struct {
 	Memory uint64
 	Swap   uint64
 	Cache  uint64
+	RSS    uint64
 
 	System          Percent
 	User            Percent

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -505,6 +505,9 @@ func extractMemStat(s string) (cache, rss uint64) {
 		case strings.HasPrefix(text, "anon "):
 			rss = read(text)
 		}
+		if cache != 0 && rss != 0 {
+			break // both found, stop scanning
+		}
 	}
 	return
 }

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -248,7 +247,7 @@ func (e *exe) Stats() *resources.Utilization {
 	swapCurrent, _ := strconv.Atoi(swapCurrentS)
 
 	memStatS, _ := e.readCG("memory.stat")
-	memCache := extractRe(memStatS)
+	memCache, memRSS := extractMemStat(memStatS)
 
 	cpuStatsS, _ := e.readCG("cpu.stat")
 	usr, system, total := extractCPU(cpuStatsS)
@@ -262,6 +261,7 @@ func (e *exe) Stats() *resources.Utilization {
 		Memory: uint64(memCurrent),
 		Swap:   uint64(swapCurrent),
 		Cache:  memCache,
+		RSS:    memRSS,
 
 		// cpu stats
 		System:  systemPct,
@@ -490,20 +490,23 @@ func (e *exe) setOomScoreAdj(pid int) error {
 	)
 }
 
-var (
-	memCacheRe = regexp.MustCompile(`file\s+(\d+)`)
-)
-
-func extractRe(s string) uint64 {
-	matches := memCacheRe.FindStringSubmatch(s)
-	if len(matches) != 2 {
-		return 0
+func extractMemStat(s string) (cache, rss uint64) {
+	read := func(line string) uint64 {
+		num := line[strings.Index(line, " ")+1:]
+		v, _ := strconv.ParseUint(num, 10, 64)
+		return v
 	}
-	value, err := strconv.ParseInt(matches[1], 10, 64)
-	if err != nil {
-		return 0
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		text := scanner.Text()
+		switch {
+		case strings.HasPrefix(text, "file "):
+			cache = read(text)
+		case strings.HasPrefix(text, "anon "):
+			rss = read(text)
+		}
 	}
-	return uint64(value)
+	return
 }
 
 func extractCPU(s string) (user, system, total resources.MicroSecond) {

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -508,10 +508,11 @@ func (p *Plugin) stats(ctx context.Context, ch chan<- *drivers.TaskResourceUsage
 		ch <- &drivers.TaskResourceUsage{
 			ResourceUsage: &cstructs.ResourceUsage{
 				MemoryStats: &cstructs.MemoryStats{
+					RSS:      usage.RSS,
 					Cache:    usage.Cache,
 					Swap:     usage.Swap,
 					Usage:    usage.Memory,
-					Measured: []string{"Cache", "Swap", "Usage"},
+					Measured: []string{"RSS", "Cache", "Swap", "Usage"},
 				},
 				CpuStats: &cstructs.CpuStats{
 					UserMode:         float64(usage.User),

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -821,3 +821,74 @@ func TestFunctional_cap_add_not_allowed(t *testing.T) {
 	must.Error(t, err)
 	must.StrContains(t, err.Error(), "net_bind_service")
 }
+
+// TestFunctional_TaskStats_RSS verifies that RSS is reported as a non-zero value
+// in the MemoryStats of a running task, and that "RSS" is included in Measured.
+// RSS is derived from the "anon" field of the cgroup memory.stat file.
+func TestFunctional_TaskStats_RSS(t *testing.T) {
+	ctests.RequireRoot(t)
+	ci.Parallel(t)
+
+	pluginConfig := &Config{
+		UnveilDefaults: true,
+	}
+
+	taskConfig := &TaskConfig{
+		Command: "sleep",
+		Args:    []string{"infinity"},
+	}
+
+	allocID := uuid.Generate()
+	taskName := "test_rss_stats_" + uuid.Short()
+
+	task := &drivers.TaskConfig{
+		User:      "nomad-80000",
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		AllocID:   allocID,
+		Resources: basicResources(allocID, taskName),
+	}
+
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
+
+	harness := newTestHarness(t, pluginConfig)
+	harness.MakeTaskCgroup(task.AllocID, task.Name)
+	cleanup := harness.MkAllocDir(task, true)
+	defer cleanup()
+
+	_, _, err := harness.StartTask(task)
+	must.NoError(t, err)
+
+	defer func() {
+		_ = harness.DestroyTask(task.ID, true)
+	}()
+
+	// give the task a moment to start and populate cgroup memory.stat
+	time.Sleep(1 * time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// TaskStats returns a channel that emits on the given interval
+	statsCh, err := harness.TaskStats(ctx, task.ID, time.Second)
+	must.NoError(t, err)
+
+	select {
+	case usage := <-statsCh:
+		must.NotNil(t, usage)
+		must.NotNil(t, usage.ResourceUsage)
+
+		mem := usage.ResourceUsage.MemoryStats
+		must.NotNil(t, mem)
+
+		// RSS must be non-zero — a running process always has anonymous memory
+		// (stack at minimum). It is sourced from the "anon" field in memory.stat.
+		must.Positive(t, mem.RSS)
+
+		// "RSS" must be declared in Measured so Nomad surfaces it in the UI/API
+		must.SliceContainsAll(t, mem.Measured, []string{"RSS", "Cache", "Swap", "Usage"})
+
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for task stats")
+	}
+}

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -853,24 +853,21 @@ func TestFunctional_TaskStats_RSS(t *testing.T) {
 
 	harness := newTestHarness(t, pluginConfig)
 	harness.MakeTaskCgroup(task.AllocID, task.Name)
-	cleanup := harness.MkAllocDir(task, true)
-	defer cleanup()
+	t.Cleanup(harness.MkAllocDir(task, true))
 
 	_, _, err := harness.StartTask(task)
 	must.NoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		_ = harness.DestroyTask(task.ID, true)
-	}()
+	})
 
-	// give the task a moment to start and populate cgroup memory.stat
-	time.Sleep(1 * time.Second)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	// TaskStats returns a channel that emits on the given interval
-	statsCh, err := harness.TaskStats(ctx, task.ID, time.Second)
+	// TaskStats emits on the given interval; the first emission populates cgroup
+	// memory.stat values. 200ms is fast enough to not slow the test suite.
+	statsCh, err := harness.TaskStats(ctx, task.ID, 200*time.Millisecond)
 	must.NoError(t, err)
 
 	select {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/2

**_Summary_**

Task memory stats now report `RSS`. Previously the driver read `memory.stat` but only extracted the file field (page cache). The anon field, the cgroups v2 equivalent of RSS was never read, so RSS was always zero and the Nomad UI/API showed no Memory Stats section at all for exec2 tasks.

**_BackGround_**

cgroups v1 exposed a dedicated rss key in `memory.stat`. cgroups v2 removed it and replaced it with two separate fields:

Field | Meaning
-- | --
anon | Anonymous resident memory — heap, stack, mmap-anonymous. This is RSS.
file | Page cache — filesystem-backed memory. 

The exec and docker Nomad drivers already handle it by reading anon as the RSS source on cgroups v2. This PR brings exec2 into line with that behaviour.

**_The issue_**

The driver already read `memory.stat` on every stats tick but only parsed the file field via a `regex (file\s+(\d+))`. The anon field was ignored. `Utilization.RSS` did not exist. `cstructs.MemoryStats.RSS` was never set. "RSS" was absent from the Measured slice.

**_Data flow — before vs after_**

Before:

```
memory.stat → extractRe() [regex: file\s+(\d+)] → cache only
    └── Utilization{ Memory, Swap, Cache }
        └── MemoryStats{ Cache, Swap, Usage }   Measured: ["Cache","Swap","Usage"]
```

After:

```
memory.stat → extractMemStat() [scanner: "file "→cache, "anon "→rss] → cache + rss
    └── Utilization{ Memory, Swap, Cache, RSS }
        └── MemoryStats{ RSS, Cache, Swap, Usage }   Measured: ["RSS","Cache","Swap","Usage"]
```

**_Testing_**

<details>

1)
```
job "rss" { 
  type = "service" 
 
  constraint { 
    attribute = "${attr.kernel.name}" 
    value     = "linux" 
  } 
 
  group "group" { 
    reschedule { 
      attempts  = 0 
      unlimited = false 
    } 
 
    restart { 
      attempts = 0 
      mode     = "fail" 
    } 
 
    task "sleep" { 
      driver = "exec2" 
 
      config { 
        command = "sleep" 
        args    = ["infinity"] 
      } 
 
      resources { 
        cpu    = 100 
        memory = 64 
      } 
    } 
  } 
}
```

**Result Before:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ cat "$CGROUP_PATH/memory.stat"

anon 36790272
file 24576
kernel 0
kernel_stack 0
pagetables 0
sec_pagetables 0
percpu 0
sock 0
vmalloc 0
shmem 0
file_mapped 24576
file_dirty 0
file_writeback 0
swapcached 0
anon_thp 0
file_thp 0
shmem_thp 0
inactive_anon 0
active_anon 36790272
inactive_file 24576
active_file 0
unevictable 0
slab_reclaimable 0
slab_unreclaimable 0
slab 0
workingset_refault_anon 0
workingset_refault_file 9
workingset_activate_anon 0
workingset_activate_file 8
workingset_restore_anon 0
workingset_restore_file 0
workingset_nodereclaim 0
pgdemote_kswapd 0
pgdemote_direct 0
pgdemote_khugepaged 0
pgdemote_proactive 0
pgscan 3251
pgsteal 2717
pswpin 0
pswpout 0
pgscan_kswapd 0
pgscan_direct 0
pgscan_khugepaged 0
pgscan_proactive 3251
pgsteal_kswapd 0
pgsteal_direct 0
pgsteal_khugepaged 0
pgsteal_proactive 2717
pgfault 5758
pgmajfault 6
pgrefill 1
pgactivate 10
pgdeactivate 0
pglazyfree 0
pglazyfreed 0
swpin_zero 0
swpout_zero 0
thp_fault_alloc 0
thp_collapse_alloc 0
thp_swpout 0
thp_swpout_fallback 0

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ grep "^rss " "$CGROUP_PATH/memory.stat" || echo "No rss key (expected on cgroupsv2)"
No rss key (expected on cgroupsv2)

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ cat "$CGROUP_PATH/memory.current"
37748736

riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ SHORT_ALLOC_ID=$(nomad job status rss | grep -E '^[a-f0-9]{8}' | awk '{print $1}')
FULL_ALLOC_ID=$(nomad alloc status $SHORT_ALLOC_ID | grep '^ID' | awk '{print $3}')

curl -s "http://127.0.0.1:4646/v1/client/allocation/${FULL_ALLOC_ID}/stats" | \
  python3 -m json.tool | grep -A 10 '"MemoryStats"'
        "MemoryStats": {
            "RSS": 0,
            "Cache": 0,
            "Swap": 0,
            "MappedFile": 0,
            "Usage": 37748736,
            "MaxUsage": 0,
            "KernelUsage": 0,
            "KernelMaxUsage": 0,
            "Measured": [
                "Cache",
--
                "MemoryStats": {
                    "RSS": 0,
                    "Cache": 0,
                    "Swap": 0,
                    "MappedFile": 0,
                    "Usage": 37748736,
                    "MaxUsage": 0,
                    "KernelUsage": 0,
                    "KernelMaxUsage": 0,
                    "Measured": [
                        "Cache",
```

**Result After:**

```
riteshharihar@podman-dev:/Users/riteshharihar/Desktop/Src/nomad-driver-exec2$ SHORT_ALLOC_ID=$(nomad job status rss | grep -E '^[a-f0-9]{8}' | awk '{print $1}')
FULL_ALLOC_ID=$(nomad alloc status $SHORT_ALLOC_ID | grep '^ID' | awk '{print $3}')

curl -s "http://127.0.0.1:4646/v1/client/allocation/${FULL_ALLOC_ID}/stats" | \
  python3 -m json.tool | grep -A 10 '"MemoryStats"'
        "MemoryStats": {
            "RSS": 36392960,
            "Cache": 0,
            "Swap": 0,
            "MappedFile": 0,
            "Usage": 37568512,
            "MaxUsage": 0,
            "KernelUsage": 0,
            "KernelMaxUsage": 0,
            "Measured": [
                "RSS",
--
                "MemoryStats": {
                    "RSS": 36392960,
                    "Cache": 0,
                    "Swap": 0,
                    "MappedFile": 0,
                    "Usage": 37568512,
                    "MaxUsage": 0,
                    "KernelUsage": 0,
                    "KernelMaxUsage": 0,
                    "Measured": [
                        "RSS",

```

<img width="685" height="218" alt="Screenshot 2026-09-03 at 1 11 44 PM" src="https://github.com/user-attachments/assets/e148ab74-f26c-43f4-b5ed-9601e1717b55" />


</details>






<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

